### PR TITLE
Change UIKit import to Foundation

### DIFF
--- a/SWXMLHashPlayground.playground/section-1.swift
+++ b/SWXMLHashPlayground.playground/section-1.swift
@@ -1,7 +1,7 @@
 // Playground - noun: a place where people can play
 
 import SWXMLHash
-import UIKit
+import Foundation
 
 let xmlWithNamespace = "<root xmlns:h=\"http://www.w3.org/TR/html4/\"" +
 "  xmlns:f=\"http://www.w3schools.com/furniture\">" +

--- a/Source/SWXMLHash.h
+++ b/Source/SWXMLHash.h
@@ -6,7 +6,7 @@
 //
 //
 
-#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
 
 //! Project version number for SWXMLHash.
 FOUNDATION_EXPORT double SWXMLHashVersionNumber;


### PR DESCRIPTION
Foundation is inherited by UIKit and Coca frameworks
https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/ObjC_classic/index.html

It did break the test