### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Quick"]
 	path = Quick
-	url = git@github.com:Quick/Quick.git
+	url = https://github.com/Quick/Quick.git


### PR DESCRIPTION
This is a small patch to change the link to the *Quick* project from `git` to `https`.

This is to prevent the user being asked to confirm the authenticity of github.com. Which is something that will not work in non-interactive builds like on *Travis* or other CI systems.

```
carthage update --no-build
*** Cloning Alamofire
*** Cloning Snap
*** Cloning GCDWebServer
*** Cloning KIF
*** Cloning SWXMLHash
*** Checking out Alamofire at "1.1.4"
*** Checking out GCDWebServer at "3.2.2"
*** Checking out KIF at "v3.1.2"
*** Checking out SWXMLHash at "0.6.2"
*** Checking out Snap at "0.0.6"
The authenticity of host 'github.com (192.30.252.129)' can't be established.
RSA key fingerprint is 16:27:ac:a5:76:28:2d:36:63:1b:56:4d:eb:df:a6:48.
Are you sure you want to continue connecting (yes/no)? 
```
