### PR TITLE
Various fixes for the Xcode 6.3 branch

### DIFF
--- a/SWXMLHash.xcodeproj/project.pbxproj
+++ b/SWXMLHash.xcodeproj/project.pbxproj
@@ -18,7 +18,7 @@
 		CD741F201A9794460096D5CA /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD741F031A9793E30096D5CA /* Quick.framework */; };
 		CD7934C31A7581DF00867857 /* SWXMLHashSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD608401196CA106000B4F8D /* SWXMLHashSpecs.swift */; };
 		CD7934C41A7581E600867857 /* test.xml in Resources */ = {isa = PBXBuildFile; fileRef = CD4B5F3919E2C42D005C1F33 /* test.xml */; };
-		CD7934C51A7581F200867857 /* SWXMLHash.h in Headers */ = {isa = PBXBuildFile; fileRef = CD6083F4196CA106000B4F8D /* SWXMLHash.h */; };
+		CD7934C51A7581F200867857 /* SWXMLHash.h in Headers */ = {isa = PBXBuildFile; fileRef = CD6083F4196CA106000B4F8D /* SWXMLHash.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CD7934C61A7581F500867857 /* SWXMLHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD60840B196CA11D000B4F8D /* SWXMLHash.swift */; };
 		CD9D05371A757D8B003CCB21 /* SWXMLHash.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD9D052C1A757D8B003CCB21 /* SWXMLHash.framework */; };
 /* End PBXBuildFile section */

--- a/SWXMLHash.xcodeproj/xcshareddata/xcschemes/SWXMLHash.xcscheme
+++ b/SWXMLHash.xcodeproj/xcshareddata/xcschemes/SWXMLHash.xcscheme
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0630"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CD6083EE196CA106000B4F8D"
+               BuildableName = "SWXMLHash.framework"
+               BlueprintName = "SWXMLHash"
+               ReferencedContainer = "container:SWXMLHash.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CD6083F9196CA106000B4F8D"
+               BuildableName = "SWXMLHashTests.xctest"
+               BlueprintName = "SWXMLHashTests"
+               ReferencedContainer = "container:SWXMLHash.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CD6083F9196CA106000B4F8D"
+               BuildableName = "SWXMLHashTests.xctest"
+               BlueprintName = "SWXMLHashTests"
+               ReferencedContainer = "container:SWXMLHash.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CD6083EE196CA106000B4F8D"
+            BuildableName = "SWXMLHash.framework"
+            BlueprintName = "SWXMLHash"
+            ReferencedContainer = "container:SWXMLHash.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CD6083EE196CA106000B4F8D"
+            BuildableName = "SWXMLHash.framework"
+            BlueprintName = "SWXMLHash"
+            ReferencedContainer = "container:SWXMLHash.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CD6083EE196CA106000B4F8D"
+            BuildableName = "SWXMLHash.framework"
+            BlueprintName = "SWXMLHash"
+            ReferencedContainer = "container:SWXMLHash.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SWXMLHash.xcodeproj/xcshareddata/xcschemes/SWXMLHashOSX.xcscheme
+++ b/SWXMLHash.xcodeproj/xcshareddata/xcschemes/SWXMLHashOSX.xcscheme
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0630"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CD9D052B1A757D8B003CCB21"
+               BuildableName = "SWXMLHash.framework"
+               BlueprintName = "SWXMLHashOSX"
+               ReferencedContainer = "container:SWXMLHash.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CD9D05351A757D8B003CCB21"
+               BuildableName = "SWXMLHashOSXTests.xctest"
+               BlueprintName = "SWXMLHashOSXTests"
+               ReferencedContainer = "container:SWXMLHash.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CD9D05351A757D8B003CCB21"
+               BuildableName = "SWXMLHashOSXTests.xctest"
+               BlueprintName = "SWXMLHashOSXTests"
+               ReferencedContainer = "container:SWXMLHash.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CD9D052B1A757D8B003CCB21"
+            BuildableName = "SWXMLHash.framework"
+            BlueprintName = "SWXMLHashOSX"
+            ReferencedContainer = "container:SWXMLHash.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CD9D052B1A757D8B003CCB21"
+            BuildableName = "SWXMLHash.framework"
+            BlueprintName = "SWXMLHashOSX"
+            ReferencedContainer = "container:SWXMLHash.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CD9D052B1A757D8B003CCB21"
+            BuildableName = "SWXMLHash.framework"
+            BlueprintName = "SWXMLHashOSX"
+            ReferencedContainer = "container:SWXMLHash.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SWXMLHashPlayground.playground/contents.xcplayground
+++ b/SWXMLHashPlayground.playground/contents.xcplayground
@@ -3,5 +3,4 @@
     <sections>
         <code source-file-name='section-1.swift'/>
     </sections>
-    <timeline fileName='timeline.xctimeline'/>
 </playground>

--- a/SWXMLHashPlayground.playground/timeline.xctimeline
+++ b/SWXMLHashPlayground.playground/timeline.xctimeline
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Timeline
-   version = "3.0">
-   <TimelineItems>
-   </TimelineItems>
-</Timeline>

--- a/Source/SWXMLHash.swift
+++ b/Source/SWXMLHash.swift
@@ -126,7 +126,7 @@ class LazyXMLParser : NSObject, NSXMLParserDelegate {
             current.text = ""
         }
 
-        parentStack.top().text! += string!.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet())
+        parentStack.top().text! += string!
     }
 
     func parser(parser: NSXMLParser, didEndElement elementName: String, namespaceURI: String?, qualifiedName qName: String?) {
@@ -185,7 +185,7 @@ class XMLParser : NSObject, NSXMLParserDelegate {
             current.text = ""
         }
 
-        parentStack.top().text! += string!.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet())
+        parentStack.top().text! += string!
     }
 
     func parser(parser: NSXMLParser, didEndElement elementName: String, namespaceURI: String?, qualifiedName qName: String?) {


### PR DESCRIPTION
First off, thanks for building this! I'm thankful I didn't have to suffer through the insanity of writing more NSXMLParser boilerplate.

I'm proposing a few changes in this PR:

- **Made OSX umbrella header public:** without this change, the SWXMLHashOSX target simply won't build.
- **Shared schemes:** This will allow building with [Carthage](/Carthage/Carthage) and will simplify making changes to how these schemes should be built.
- **Removed whitespace and newline trimming:** When evaluating SWXMLHash in my project, I was wondering why the spacing was different than what was present in the XML (which is very important in my case). It was only after looking at the source that I found out this framework automatically trimmed whitespace. It doesn't seem like the responsibility of this framework to trim whitespace, and it's very simple for an end user to do so themselves, so I feel strongly that this should be removed.

I can make multiple PR's for this if you prefer keeping things focused.