### PR TITLE
Add fluent configuration option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v1.2.0 (June 20, 2015)
+
+* Add `configure` method off of `SWXMLHash` to allow for setting variable number of options.
+    * At this time, the only options are `shouldProcessLazily` and `shouldProcessNamespaces`.
+    * `shouldProcessLazily` provides the same parsing as directly calling `lazy`. I'm considering deprecating the top-level `lazy` method in favor of having it be set in `configure`, but I'm open to suggestions here (as well as to suggestions regarding the `configure` method in general).
+    * `shouldProcessNamespaces` provides the functionality requested in [issue #30](https://github.com/drmohundro/SWXMLHash/issues/30).
+
 ## v1.0.1 (May 18, 2015)
 
 * Quick/Nimble are no longer used via git submodules, but are instead being pulled in via Carthage.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The API takes a lot of inspiration from [SwiftyJSON](https://github.com/SwiftyJS
 
 * [Installation](#installation)
 * [Getting Started](#getting-started)
+* [Configuration](#configuration)
 * [Examples](#examples)
 * [Changelog](#changelog)
 * [Contributing](#contributing)
@@ -70,6 +71,26 @@ If you're just getting started with SWXMLHash, I'd recommend cloning the reposit
 
 <img src="https://raw.githubusercontent.com/drmohundro/SWXMLHash/assets/swift-playground@2x.png" width="600" alt="Swift Playground" />
 
+## Configuration
+
+SWXMLHash allows for limited configuration in terms of its approach to parsing. To set any of the configuration options, you use the `configure` method, like so:
+
+```swift
+let xml = SWXMLHash.config {
+              config in
+              // set any config options here
+          }.parse(xmlToParse)
+```
+
+The available options at this time are:
+
+* `shouldProcessLazily`
+    * This determines whether not to use lazy loading of the XML. It can significantly increase the performance of parsing if your XML is very large.
+    * Defaults to `false`
+* `shouldProcessNamespaces`
+    * This setting is forwarded on to the internal `NSXMLParser` instance. It will return any XML elements without their namespace parts (i.e. "\<h:table\>" will be returned as "\<table\>")
+    * Defaults to `false`
+
 ## Examples
 
 All examples below can be found in the included specs.
@@ -80,7 +101,16 @@ All examples below can be found in the included specs.
 let xml = SWXMLHash.parse(xmlToParse)
 ```
 
-Alternatively, for lazy parsing support, you call `lazy` instead of `parse`. Lazy loading avoids loading the entire XML document into memory, so it could be preferable for performance reasons. See the error handling for one caveat regarding lazy loading.
+Alternatively, if you're parsing a large XML file and need the best performance, you may wish to configure the parsing to be processed lazily. Lazy processing avoids loading the entire XML document into memory, so it could be preferable for performance reasons. See the error handling for one caveat regarding lazy loading.
+
+```swift
+let xml = SWXMLHash.config {
+              config in
+              config.shouldProcessLazily = true
+          }.parse(xmlToParse)
+```
+
+The above approach uses the new config method, but there is also a `lazy` method directly off of `SWXMLHash`.
 
 ```swift
 let xml = SWXMLHash.lazy(xmlToParse)

--- a/SWXMLHashPlayground.playground/contents.xcplayground
+++ b/SWXMLHashPlayground.playground/contents.xcplayground
@@ -3,4 +3,5 @@
     <sections>
         <code source-file-name='section-1.swift'/>
     </sections>
+    <timeline fileName='timeline.xctimeline'/>
 </playground>

--- a/SWXMLHashPlayground.playground/timeline.xctimeline
+++ b/SWXMLHashPlayground.playground/timeline.xctimeline
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Timeline
+   version = "3.0">
+   <TimelineItems>
+   </TimelineItems>
+</Timeline>

--- a/Tests/SWXMLHashSpecs.swift
+++ b/Tests/SWXMLHashSpecs.swift
@@ -152,7 +152,7 @@ class SWXMLHashLazyTests: QuickSpec {
         var xml = XMLIndexer("to be set")
 
         beforeEach {
-            xml = SWXMLHash.lazy(xmlToParse)
+            xml = SWXMLHash.config { config in config.shouldProcessLazily = true }.parse(xmlToParse)
         }
 
         describe("lazy xml parsing") {

--- a/Tests/SWXMLHashSpecs.swift
+++ b/Tests/SWXMLHashSpecs.swift
@@ -235,3 +235,30 @@ class SWXMLHashLazyTests: QuickSpec {
         }
     }
 }
+
+class SWXMLHashConfigSpecs: QuickSpec {
+    override func spec() {
+        describe("optional configuration options for NSXMLParser") {
+            var parser = XMLIndexer("not set")
+            let xmlWithNamespace = "<root xmlns:h=\"http://www.w3.org/TR/html4/\"" +
+                "  xmlns:f=\"http://www.w3schools.com/furniture\">" +
+                "  <h:table>" +
+                "    <h:tr>" +
+                "      <h:td>Apples</h:td>" +
+                "      <h:td>Bananas</h:td>" +
+                "    </h:tr>" +
+                "  </h:table>" +
+            "</root>"
+
+            beforeEach {
+                parser = SWXMLHash.config { conf in
+                    conf.shouldProcessNamespaces = true
+                }.parse(xmlWithNamespace)
+            }
+
+            it("should allow processing namespaces or not") {
+                expect(parser["root"]["table"]["tr"]["td"][0].element?.text).to(equal("Apples"))
+            }
+        }
+    }
+}


### PR DESCRIPTION
This change introduces a new fluent configuration method as a way of hopefully making it easy and straightforward to introduce new configuration options in the future.

The first config option introduced in this commit is `shouldProcessNamespaces` which is forwarded on to the `NSXMLParser` instance (related to issue #30).

There is also a config option for lazy XML parsing which can be used instead of calling "lazy" versus "parse".