### PR TITLE
Swift 2 Error handling

### DIFF
--- a/Source/SWXMLHash.swift
+++ b/Source/SWXMLHash.swift
@@ -28,10 +28,10 @@ let rootElementName = "SWXMLHash_Root_Element"
 /// Parser options
 public class SWXMLHashOptions {
     internal init() {}
-
+    
     /// determines whether to parse the XML with lazy parsing or not
     public var shouldProcessLazily = false
-
+    
     /// determines whether to parse XML namespaces or not (forwards to `NSXMLParser.shouldProcessNamespaces`)
     public var shouldProcessNamespaces = false
 }
@@ -39,64 +39,64 @@ public class SWXMLHashOptions {
 /// Simple XML parser
 public class SWXMLHash {
     let options: SWXMLHashOptions
-
+    
     private init(_ options: SWXMLHashOptions = SWXMLHashOptions()) {
         self.options = options
     }
-
+    
     class public func config(configAction: (SWXMLHashOptions) -> ()) -> SWXMLHash {
         let opts = SWXMLHashOptions()
         configAction(opts)
         return SWXMLHash(opts)
     }
-
+    
     public func parse(xml: String) -> XMLIndexer {
         return parse((xml as NSString).dataUsingEncoding(NSUTF8StringEncoding)!)
     }
-
+    
     public func parse(data: NSData) -> XMLIndexer {
         let parser: SimpleXmlParser = options.shouldProcessLazily ? LazyXMLParser(options) : XMLParser(options)
         return parser.parse(data)
     }
-
+    
     /**
     Method to parse XML passed in as a string.
-
+    
     - parameter xml: The XML to be parsed
-
+    
     - returns: An XMLIndexer instance that is used to look up elements in the XML
     */
     class public func parse(xml: String) -> XMLIndexer {
         return SWXMLHash().parse(xml)
     }
-
+    
     /**
     Method to parse XML passed in as an NSData instance.
-
+    
     - parameter xml: The XML to be parsed
-
+    
     - returns: An XMLIndexer instance that is used to look up elements in the XML
     */
     class public func parse(data: NSData) -> XMLIndexer {
         return SWXMLHash().parse(data)
     }
-
+    
     /**
     Method to lazily parse XML passed in as a string.
-
+    
     :param: xml The XML to be parsed
-
+    
     :returns: An XMLIndexer instance that is used to look up elements in the XML
     */
     class public func lazy(xml: String) -> XMLIndexer {
         return config { conf in conf.shouldProcessLazily = true }.parse(xml)
     }
-
+    
     /**
     Method to lazily parse XML passed in as an NSData instance.
-
+    
     :param: xml The XML to be parsed
-
+    
     :returns: An XMLIndexer instance that is used to look up elements in the XML
     */
     class public func lazy(data: NSData) -> XMLIndexer {
@@ -131,67 +131,67 @@ class LazyXMLParser: NSObject, SimpleXmlParser, NSXMLParserDelegate {
         self.options = options
         super.init()
     }
-
+    
     var root = XMLElement(name: rootElementName)
     var parentStack = Stack<XMLElement>()
     var elementStack = Stack<String>()
-
+    
     var data: NSData?
     var ops: [IndexOp] = []
     let options: SWXMLHashOptions
-
+    
     func parse(data: NSData) -> XMLIndexer {
         self.data = data
         return XMLIndexer(self)
     }
-
+    
     func startParsing(ops: [IndexOp]) {
         // clear any prior runs of parse... expected that this won't be necessary, but you never know
         parentStack.removeAll()
         root = XMLElement(name: rootElementName)
         parentStack.push(root)
-
+        
         self.ops = ops
         let parser = NSXMLParser(data: data!)
         parser.shouldProcessNamespaces = options.shouldProcessNamespaces
         parser.delegate = self
         parser.parse()
     }
-
+    
     func parser(parser: NSXMLParser, didStartElement elementName: String, namespaceURI: String?, qualifiedName qName: String?, attributes attributeDict: [String: String]) {
-
+        
         elementStack.push(elementName)
-
+        
         if !onMatch() {
             return
         }
         let currentNode = parentStack.top().addElement(elementName, withAttributes: attributeDict)
         parentStack.push(currentNode)
     }
-
+    
     func parser(parser: NSXMLParser, foundCharacters string: String) {
         if !onMatch() {
             return
         }
-
+        
         let current = parentStack.top()
         if current.text == nil {
             current.text = ""
         }
-
+        
         parentStack.top().text! += string
     }
-
+    
     func parser(parser: NSXMLParser, didEndElement elementName: String, namespaceURI: String?, qualifiedName qName: String?) {
         let match = onMatch()
-
+        
         elementStack.pop()
-
+        
         if match {
             parentStack.pop()
         }
     }
-
+    
     func onMatch() -> Bool {
         // we typically want to compare against the elementStack to see if it matches ops, *but*
         // if we're on the first element, we'll instead compare the other direction.
@@ -210,40 +210,40 @@ class XMLParser: NSObject, SimpleXmlParser, NSXMLParserDelegate {
         self.options = options
         super.init()
     }
-
+    
     var root = XMLElement(name: rootElementName)
     var parentStack = Stack<XMLElement>()
     let options: SWXMLHashOptions
-
+    
     func parse(data: NSData) -> XMLIndexer {
         // clear any prior runs of parse... expected that this won't be necessary, but you never know
         parentStack.removeAll()
-
+        
         parentStack.push(root)
-
+        
         let parser = NSXMLParser(data: data)
         parser.shouldProcessNamespaces = options.shouldProcessNamespaces
         parser.delegate = self
         parser.parse()
-
+        
         return XMLIndexer(root)
     }
-
+    
     func parser(parser: NSXMLParser, didStartElement elementName: String, namespaceURI: String?, qualifiedName qName: String?, attributes attributeDict: [String: String]) {
-
+        
         let currentNode = parentStack.top().addElement(elementName, withAttributes: attributeDict)
         parentStack.push(currentNode)
     }
-
+    
     func parser(parser: NSXMLParser, foundCharacters string: String) {
         let current = parentStack.top()
         if current.text == nil {
             current.text = ""
         }
-
+        
         parentStack.top().text! += string
     }
-
+    
     func parser(parser: NSXMLParser, didEndElement elementName: String, namespaceURI: String?, qualifiedName qName: String?) {
         parentStack.pop()
     }
@@ -252,30 +252,30 @@ class XMLParser: NSObject, SimpleXmlParser, NSXMLParserDelegate {
 public class IndexOp {
     var index: Int
     let key: String
-
+    
     init(_ key: String) {
         self.key = key
         self.index = -1
     }
-
+    
     func toString() -> String {
         if index >= 0 {
             return key + " " + index.description
         }
-
+        
         return key
     }
 }
 
 public class IndexOps {
     var ops: [IndexOp] = []
-
+    
     let parser: LazyXMLParser
-
+    
     init(parser: LazyXMLParser) {
         self.parser = parser
     }
-
+    
     func findElements() -> XMLIndexer {
         parser.startParsing(ops)
         let indexer = XMLIndexer(parser.root)
@@ -289,7 +289,7 @@ public class IndexOps {
         ops.removeAll(keepCapacity: false)
         return childIndex
     }
-
+    
     func stringify() -> String {
         var s = ""
         for op in ops {
@@ -304,8 +304,17 @@ public enum XMLIndexer: SequenceType {
     case Element(XMLElement)
     case List([XMLElement])
     case Stream(IndexOps)
-    case Error(NSError)
-
+    case Error(XMLIndexerError)
+    
+    public enum XMLIndexerError: ErrorType {
+        case Attribute(attr: String)
+        case AttributeValue(attr: String, value: String)
+        case Key(key: String)
+        case Index(idx: Int)
+        case Init(instance: AnyObject)
+        case Error
+    }
+    
     /// The underlying XMLElement at the currently indexed level of XML.
     public var element: XMLElement? {
         switch self {
@@ -318,7 +327,7 @@ public enum XMLIndexer: SequenceType {
             return nil
         }
     }
-
+    
     /// All elements at the currently indexed level
     public var all: [XMLIndexer] {
         switch self {
@@ -337,7 +346,7 @@ public enum XMLIndexer: SequenceType {
             return []
         }
     }
-
+    
     /// All child elements from the currently indexed level
     public var children: [XMLIndexer] {
         var list = [XMLIndexer]()
@@ -348,68 +357,80 @@ public enum XMLIndexer: SequenceType {
         }
         return list
     }
-
+    
     /**
     Allows for element lookup by matching attribute values.
-
+    
     - parameter attr: should the name of the attribute to match on
     - parameter value: should be the value of the attribute to match on
-
+    
     - returns: instance of XMLIndexer
     */
-    public func withAttr(attr: String, _ value: String) -> XMLIndexer {
-        let attrUserInfo = [NSLocalizedDescriptionKey: "XML Attribute Error: Missing attribute [\"\(attr)\"]"]
-        let valueUserInfo = [NSLocalizedDescriptionKey: "XML Attribute Error: Missing attribute [\"\(attr)\"] with value [\"\(value)\"]"]
+    public func withAttr(attr: String, _ value: String) throws -> XMLIndexer {
         switch self {
         case .Stream(let opStream):
             opStream.stringify()
             let match = opStream.findElements()
-            return match.withAttr(attr, value)
+            return try match.withAttr(attr, value)
         case .List(let list):
             if let elem = list.filter({$0.attributes[attr] == value}).first {
                 return .Element(elem)
             }
-            return .Error(NSError(domain: "SWXMLDomain", code: 1000, userInfo: valueUserInfo))
+            throw XMLIndexerError.AttributeValue(attr: attr, value: value)
         case .Element(let elem):
             if let attr = elem.attributes[attr] {
                 if attr == value {
                     return .Element(elem)
                 }
-                return .Error(NSError(domain: "SWXMLDomain", code: 1000, userInfo: valueUserInfo))
+                throw XMLIndexerError.AttributeValue(attr: attr, value: value)
             }
-            return .Error(NSError(domain: "SWXMLDomain", code: 1000, userInfo: attrUserInfo))
+            fallthrough
         default:
-            return .Error(NSError(domain: "SWXMLDomain", code: 1000, userInfo: attrUserInfo))
+            throw XMLIndexerError.Attribute(attr: attr)
         }
     }
-
+    
     /**
     Initializes the XMLIndexer
-
+    
     - parameter _: should be an instance of XMLElement, but supports other values for error handling
-
+    
     - returns: instance of XMLIndexer
     */
-    public init(_ rawObject: AnyObject) {
+    public init(_ rawObject: AnyObject) throws {
         switch rawObject {
         case let value as XMLElement:
             self = .Element(value)
         case let value as LazyXMLParser:
             self = .Stream(IndexOps(parser: value))
         default:
-            self = .Error(NSError(domain: "SWXMLDomain", code: 1000, userInfo: nil))
+            throw XMLIndexerError.Init(instance: rawObject)
         }
     }
-
+    
+    public init(_ el: XMLElement) {
+        self = .Element(el)
+    }
+    
+    init(_ stream: LazyXMLParser) {
+        self = .Stream(IndexOps(parser: stream))
+    }
+    
+    
     /**
     Find an XML element at the current level by element name
-
+    
     - parameter key: The element name to index by
-
+    
     - returns: instance of XMLIndexer to match the element (or elements) found by key
+    
+    - errors: throws a XMLIndexerError.Key if no element was found
+
     */
-    public subscript(key: String) -> XMLIndexer {
-        let userInfo = [NSLocalizedDescriptionKey: "XML Element Error: Incorrect key [\"\(key)\"]"]
+    
+    //Because Swift 2 does not support throwing subscripts I added an function that throws.
+    //Maybe can be change in the future if support for throwing subscripts is added.
+    public func key(key: String) throws -> XMLIndexer {
         switch self {
         case .Stream(let opStream):
             let op = IndexOp(key)
@@ -425,21 +446,41 @@ public enum XMLIndexer: SequenceType {
                     return .List(match)
                 }
             }
-            return .Error(NSError(domain: "SWXMLDomain", code: 1000, userInfo: userInfo))
+            fallthrough
         default:
-            return .Error(NSError(domain: "SWXMLDomain", code: 1000, userInfo: userInfo))
+            throw XMLIndexerError.Key(key: key)
         }
     }
-
+    
+    /**
+    Find an XML element at the current level by element name
+    
+    - parameter key: The element name to index by
+    
+    - returns: instance of XMLIndexer to match the element (or elements) found by
+    
+    */
+    
+    public subscript(key: String) -> XMLIndexer {
+        do {
+           return try self.key(key)
+        } catch let error as XMLIndexerError {
+            return .Error(error)
+        } catch {
+            return .Error(.Key(key: key))
+        }
+    }
+    
     /**
     Find an XML element by index within a list of XML Elements at the current level
-
+    
     - parameter index: The 0-based index to index by
-
+    
     - returns: instance of XMLIndexer to match the element (or elements) found by key
     */
-    public subscript(index: Int) -> XMLIndexer {
-        let userInfo = [NSLocalizedDescriptionKey: "XML Element Error: Incorrect index [\"\(index)\"]"]
+    
+    //Because Swift 2 does not support throwing subscripts I added an function that throws.
+    public func idx(index: Int) throws -> XMLIndexer {
         switch self {
         case .Stream(let opStream):
             opStream.ops[opStream.ops.count - 1].index = index
@@ -448,21 +489,29 @@ public enum XMLIndexer: SequenceType {
             if index <= list.count {
                 return .Element(list[index])
             }
-            return .Error(NSError(domain: "SWXMLDomain", code: 1000, userInfo: userInfo))
+            return .Error(.Index(idx: index))
         case .Element(let elem):
             if index == 0 {
                 return .Element(elem)
             }
-            else {
-                return .Error(NSError(domain: "SWXMLDomain", code: 1000, userInfo: userInfo))
-            }
+            fallthrough
         default:
-            return .Error(NSError(domain: "SWXMLDomain", code: 1000, userInfo: userInfo))
+            return .Error(.Index(idx: index))
         }
     }
-
+    
+    public subscript(index: Int) -> XMLIndexer {
+        do {
+            return try idx(index)
+        }  catch let error as XMLIndexerError {
+            return .Error(error)
+        } catch {
+            return .Error(.Index(idx: index))
+        }
+    }
+    
     typealias GeneratorType = XMLIndexer
-
+    
     public func generate() -> IndexingGenerator<[XMLIndexer]> {
         return all.generate()
     }
@@ -490,10 +539,29 @@ extension XMLIndexer: CustomStringConvertible {
             if elem.name == rootElementName {
                 return "\n".join(elem.children.map { $0.description })
             }
-
+            
             return elem.description
         default:
             return ""
+        }
+    }
+}
+
+extension XMLIndexer.XMLIndexerError: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .Attribute(let attr):
+            return "XML Attribute Error: Missing attribute [\"\(attr)\"]"
+        case .AttributeValue(let attr, let value):
+            return "XML Attribute Error: Missing attribute [\"\(attr)\"] with value [\"\(value)\"]"
+        case .Key(let key):
+            return "XML Element Error: Incorrect key [\"\(key)\"]"
+        case .Index(let index):
+            return "XML Element Error: Incorrect index [\"\(index)\"]"
+        case .Init(let instance):
+            return "XML Indexer Error: initialization with Object [\"\(instance)\"]"
+        case .Error:
+            return "Unknown Error"
         }
     }
 }
@@ -506,44 +574,44 @@ public class XMLElement {
     public var text: String?
     /// The attributes of the element
     public var attributes = [String:String]()
-
+    
     var children = [XMLElement]()
     var count: Int = 0
     var index: Int
-
+    
     /**
     Initialize an XMLElement instance
-
+    
     - parameter name: The name of the element to be initialized
-
+    
     - returns: a new instance of XMLElement
     */
     init(name: String, index: Int = 0) {
         self.name = name
         self.index = index
     }
-
+    
     /**
     Adds a new XMLElement underneath this instance of XMLElement
-
+    
     - parameter name: The name of the new element to be added
     - parameter withAttributes: The attributes dictionary for the element being added
-
+    
     - returns: The XMLElement that has now been added
     */
     func addElement(name: String, withAttributes attributes: NSDictionary) -> XMLElement {
         let element = XMLElement(name: name, index: count)
         count++
-
+        
         children.append(element)
-
+        
         for (keyAny,valueAny) in attributes {
             if let key = keyAny as? String,
                 let value = valueAny as? String {
-                element.attributes[key] = value
+                    element.attributes[key] = value
             }
         }
-
+        
         return element
     }
 }
@@ -556,12 +624,12 @@ extension XMLElement: CustomStringConvertible {
                 attributesStringList.append("\(key)=\"\(val)\"")
             }
         }
-
+        
         var attributesString = " ".join(attributesStringList)
         if !attributesString.isEmpty {
             attributesString = " " + attributesString
         }
-
+        
         if children.count > 0 {
             var xmlReturn = [String]()
             xmlReturn.append("<\(name)\(attributesString)>")
@@ -571,7 +639,7 @@ extension XMLElement: CustomStringConvertible {
             xmlReturn.append("</\(name)>")
             return "\n".join(xmlReturn)
         }
-
+        
         if text != nil {
             return "<\(name)\(attributesString)>\(text!)</\(name)>"
         }

--- a/Tests/SWXMLHashSpecs.swift
+++ b/Tests/SWXMLHashSpecs.swift
@@ -122,26 +122,26 @@ class SWXMLHashTests: QuickSpec {
             }
 
             it("should provide an error object when keys don't match") {
-                var err: XMLIndexer.XMLIndexerError?
+                var err: XMLIndexer.Error?
                 defer {
                     expect(err).toNot(beNil())
                 }
                 do {
-                    try xml!.key("root").key("what").key("header").key("foo")
-                } catch let error as XMLIndexer.XMLIndexerError {
+                    try xml!.byKey("root").byKey("what").byKey("header").byKey("foo")
+                } catch let error as XMLIndexer.Error {
                     err = error
                 } catch { err = nil }
                 
             }
 
             it("should provide an error element when indexers don't match") {
-                var err: XMLIndexer.XMLIndexerError?
+                var err: XMLIndexer.Error?
                 defer {
                     expect(err).toNot(beNil())
                 }
                 do {
-                    try xml!.key("what").key("subelement").idx(5).key("nomatch")
-                } catch let error as XMLIndexer.XMLIndexerError {
+                    try xml!.byKey("what").byKey("subelement").byIndex(5).byKey("nomatch")
+                } catch let error as XMLIndexer.Error {
                     err = error
                 } catch { err = nil }
             }

--- a/Tests/SWXMLHashSpecs.swift
+++ b/Tests/SWXMLHashSpecs.swift
@@ -29,7 +29,7 @@ class SWXMLHashTests: QuickSpec {
     override func spec() {
         let xmlToParse = "<root><header>header mixed content<title>Test Title Header</title>more mixed content</header><catalog><book id=\"bk101\"><author>Gambardella, Matthew</author><title>XML Developer's Guide</title><genre>Computer</genre><price>44.95</price><publish_date>2000-10-01</publish_date><description>An in-depth look at creating applications with XML.</description></book><book id=\"bk102\"><author>Ralls, Kim</author><title>Midnight Rain</title><genre>Fantasy</genre><price>5.95</price><publish_date>2000-12-16</publish_date><description>A former architect battles corporate zombies, an evil sorceress, and her own childhood to become queen of the world.</description></book><book id=\"bk103\"><author>Corets, Eva</author><title>Maeve Ascendant</title><genre>Fantasy</genre><price>5.95</price><publish_date>2000-11-17</publish_date><description>After the collapse of a nanotechnology society in England, the young survivors lay the foundation for a new society.</description></book></catalog></root>"
 
-        var xml = XMLIndexer("to be set")
+        var xml: XMLIndexer?
 
         beforeEach {
             xml = SWXMLHash.parse(xmlToParse)
@@ -37,36 +37,37 @@ class SWXMLHashTests: QuickSpec {
 
         describe("xml parsing") {
             it("should be able to parse individual elements") {
-                expect(xml["root"]["header"]["title"].element?.text).to(equal("Test Title Header"))
+                expect(xml!["root"]["header"]["title"].element?.text).to(equal("Test Title Header"))
             }
 
             it("should be able to parse element groups") {
-                expect(xml["root"]["catalog"]["book"][1]["author"].element?.text).to(equal("Ralls, Kim"))
+                expect(xml!["root"]["catalog"]["book"][1]["author"].element?.text).to(equal("Ralls, Kim"))
             }
 
             it("should be able to parse attributes") {
-                expect(xml["root"]["catalog"]["book"][1].element?.attributes["id"]).to(equal("bk102"))
+                expect(xml!["root"]["catalog"]["book"][1].element?.attributes["id"]).to(equal("bk102"))
             }
 
             it("should be able to look up elements by name and attribute") {
-                expect(xml["root"]["catalog"]["book"].withAttr("id", "bk102")["author"].element?.text).to(equal("Ralls, Kim"))
+                
+                expect(try! xml!["root"]["catalog"]["book"].withAttr("id", "bk102")["author"].element?.text).to(equal("Ralls, Kim"))
             }
 
             it("should be able to iterate element groups") {
-                expect(", ".join(xml["root"]["catalog"]["book"].all.map { $0["genre"].element!.text! })).to(equal("Computer, Fantasy, Fantasy"))
+                expect(", ".join(xml!["root"]["catalog"]["book"].all.map { $0["genre"].element!.text! })).to(equal("Computer, Fantasy, Fantasy"))
             }
 
             it("should be able to iterate element groups even if only one element is found") {
-                expect(xml["root"]["header"]["title"].all.count).to(equal(1))
+                expect(xml!["root"]["header"]["title"].all.count).to(equal(1))
             }
 
             it("should be able to index element groups even if only one element is found") {
-                expect(xml["root"]["header"]["title"][0].element?.text).to(equal("Test Title Header"))
+                expect(xml!["root"]["header"]["title"][0].element?.text).to(equal("Test Title Header"))
             }
 
             it("should be able to iterate using for-in") {
                 var count = 0
-                for _ in xml["root"]["catalog"]["book"] {
+                for _ in xml!["root"]["catalog"]["book"] {
                     count++
                 }
 
@@ -74,11 +75,11 @@ class SWXMLHashTests: QuickSpec {
             }
 
             it("should be able to enumerate children") {
-                expect(", ".join(xml["root"]["catalog"]["book"][0].children.map{ $0.element!.name })).to(equal("author, title, genre, price, publish_date, description"))
+                expect(", ".join(xml!["root"]["catalog"]["book"][0].children.map{ $0.element!.name })).to(equal("author, title, genre, price, publish_date, description"))
             }
 
             it("should be able to handle mixed content") {
-                expect(xml["root"]["header"].element?.text).to(equal("header mixed contentmore mixed content"))
+                expect(xml!["root"]["header"].element?.text).to(equal("header mixed contentmore mixed content"))
             }
 
             it("should handle interleaving XML elements") {
@@ -97,7 +98,7 @@ class SWXMLHashTests: QuickSpec {
         }
 
         describe("white space parsing") {
-            var xml = XMLIndexer("to be set")
+            var xml: XMLIndexer?
 
             beforeEach {
                 let bundle = NSBundle(forClass: SWXMLHashTests.self)
@@ -107,39 +108,42 @@ class SWXMLHashTests: QuickSpec {
             }
 
             it("should be able to pull text between elements without whitespace (issue #6)") {
-                expect(xml["niotemplate"]["section"][0]["constraint"][1].element?.text).to(equal("H:|-15-[title]-15-|"))
+                expect(xml!["niotemplate"]["section"][0]["constraint"][1].element?.text).to(equal("H:|-15-[title]-15-|"))
             }
 
             it("should be able to correctly parse CDATA sections *with* whitespace") {
-                expect(xml["niotemplate"]["other"].element?.text).to(equal("\n        \n  this\n  has\n  white\n  space\n        \n    "))
+                expect(xml!["niotemplate"]["other"].element?.text).to(equal("\n        \n  this\n  has\n  white\n  space\n        \n    "))
             }
         }
 
         describe("xml parsing error scenarios") {
             it("should return nil when keys don't match") {
-                expect(xml["root"]["what"]["header"]["foo"].element?.name).to(beNil())
+                expect(xml!["root"]["what"]["header"]["foo"].element?.name).to(beNil())
             }
 
             it("should provide an error object when keys don't match") {
-                var err: NSError? = nil
-                switch xml["root"]["what"]["header"]["foo"] {
-                case .Error(let error):
-                    err = error
-                default:
-                    err = nil
+                var err: XMLIndexer.XMLIndexerError?
+                defer {
+                    expect(err).toNot(beNil())
                 }
-                expect(err).toNot(beNil())
+                do {
+                    try xml!.key("root").key("what").key("header").key("foo")
+                } catch let error as XMLIndexer.XMLIndexerError {
+                    err = error
+                } catch { err = nil }
+                
             }
 
             it("should provide an error element when indexers don't match") {
-                var err: NSError? = nil
-                switch xml["what"]["subelement"][5]["nomatch"] {
-                case .Error(let error):
-                    err = error
-                default:
-                    err = nil
+                var err: XMLIndexer.XMLIndexerError?
+                defer {
+                    expect(err).toNot(beNil())
                 }
-                expect(err).toNot(beNil())
+                do {
+                    try xml!.key("what").key("subelement").idx(5).key("nomatch")
+                } catch let error as XMLIndexer.XMLIndexerError {
+                    err = error
+                } catch { err = nil }
             }
         }
     }
@@ -149,7 +153,7 @@ class SWXMLHashLazyTests: QuickSpec {
     override func spec() {
         let xmlToParse = "<root><header>header mixed content<title>Test Title Header</title>more mixed content</header><catalog><book id=\"bk101\"><author>Gambardella, Matthew</author><title>XML Developer's Guide</title><genre>Computer</genre><price>44.95</price><publish_date>2000-10-01</publish_date><description>An in-depth look at creating applications with XML.</description></book><book id=\"bk102\"><author>Ralls, Kim</author><title>Midnight Rain</title><genre>Fantasy</genre><price>5.95</price><publish_date>2000-12-16</publish_date><description>A former architect battles corporate zombies, an evil sorceress, and her own childhood to become queen of the world.</description></book><book id=\"bk103\"><author>Corets, Eva</author><title>Maeve Ascendant</title><genre>Fantasy</genre><price>5.95</price><publish_date>2000-11-17</publish_date><description>After the collapse of a nanotechnology society in England, the young survivors lay the foundation for a new society.</description></book></catalog></root>"
 
-        var xml = XMLIndexer("to be set")
+        var xml: XMLIndexer?
 
         beforeEach {
             xml = SWXMLHash.config { config in config.shouldProcessLazily = true }.parse(xmlToParse)
@@ -157,36 +161,36 @@ class SWXMLHashLazyTests: QuickSpec {
 
         describe("lazy xml parsing") {
             it("should be able to parse individual elements") {
-                expect(xml["root"]["header"]["title"].element?.text).to(equal("Test Title Header"))
+                expect(xml!["root"]["header"]["title"].element?.text).to(equal("Test Title Header"))
             }
 
             it("should be able to parse element groups") {
-                expect(xml["root"]["catalog"]["book"][1]["author"].element?.text).to(equal("Ralls, Kim"))
+                expect(xml!["root"]["catalog"]["book"][1]["author"].element?.text).to(equal("Ralls, Kim"))
             }
 
             it("should be able to parse attributes") {
-                expect(xml["root"]["catalog"]["book"][1].element?.attributes["id"]).to(equal("bk102"))
+                expect(xml!["root"]["catalog"]["book"][1].element?.attributes["id"]).to(equal("bk102"))
             }
 
             it("should be able to look up elements by name and attribute") {
-                expect(xml["root"]["catalog"]["book"].withAttr("id", "bk102")["author"].element?.text).to(equal("Ralls, Kim"))
+                expect(try! xml!["root"]["catalog"]["book"].withAttr("id", "bk102")["author"].element?.text).to(equal("Ralls, Kim"))
             }
 
             it("should be able to iterate element groups") {
-                expect(", ".join(xml["root"]["catalog"]["book"].all.map { $0["genre"].element?.text ?? "" })).to(equal("Computer, Fantasy, Fantasy"))
+                expect(", ".join(xml!["root"]["catalog"]["book"].all.map { $0["genre"].element?.text ?? "" })).to(equal("Computer, Fantasy, Fantasy"))
             }
 
             it("should be able to iterate element groups even if only one element is found") {
-                expect(xml["root"]["header"]["title"].all.count).to(equal(1))
+                expect(xml!["root"]["header"]["title"].all.count).to(equal(1))
             }
 
             it("should be able to index element groups even if only one element is found") {
-                expect(xml["root"]["header"]["title"][0].element?.text).to(equal("Test Title Header"))
+                expect(xml!["root"]["header"]["title"][0].element?.text).to(equal("Test Title Header"))
             }
 
             it("should be able to iterate using for-in") {
                 var count = 0
-                for _ in xml["root"]["catalog"]["book"] {
+                for _ in xml!["root"]["catalog"]["book"] {
                     count++
                 }
 
@@ -194,11 +198,11 @@ class SWXMLHashLazyTests: QuickSpec {
             }
 
             it("should be able to enumerate children") {
-                expect(", ".join(xml["root"]["catalog"]["book"][0].children.map{ $0.element?.name ?? "" })).to(equal("author, title, genre, price, publish_date, description"))
+                expect(", ".join(xml!["root"]["catalog"]["book"][0].children.map{ $0.element?.name ?? "" })).to(equal("author, title, genre, price, publish_date, description"))
             }
 
             it("should be able to handle mixed content") {
-                expect(xml["root"]["header"].element?.text).to(equal("header mixed contentmore mixed content"))
+                expect(xml!["root"]["header"].element?.text).to(equal("header mixed contentmore mixed content"))
             }
 
             it("should handle interleaving XML elements") {
@@ -210,7 +214,7 @@ class SWXMLHashLazyTests: QuickSpec {
         }
 
         describe("white space parsing") {
-            var xml = XMLIndexer("to be set")
+            var xml: XMLIndexer?
 
             beforeEach {
                 let bundle = NSBundle(forClass: SWXMLHashTests.self)
@@ -220,17 +224,17 @@ class SWXMLHashLazyTests: QuickSpec {
             }
 
             it("should be able to pull text between elements without whitespace (issue #6)") {
-                expect(xml["niotemplate"]["section"][0]["constraint"][1].element?.text).to(equal("H:|-15-[title]-15-|"))
+                expect(xml!["niotemplate"]["section"][0]["constraint"][1].element?.text).to(equal("H:|-15-[title]-15-|"))
             }
 
             it("should be able to correctly parse CDATA sections *with* whitespace") {
-                expect(xml["niotemplate"]["other"].element?.text).to(equal("\n        \n  this\n  has\n  white\n  space\n        \n    "))
+                expect(xml!["niotemplate"]["other"].element?.text).to(equal("\n        \n  this\n  has\n  white\n  space\n        \n    "))
             }
         }
 
         describe("xml parsing error scenarios") {
             it("should return nil when keys don't match") {
-                expect(xml["root"]["what"]["header"]["foo"].element?.name).to(beNil())
+                expect(xml!["root"]["what"]["header"]["foo"].element?.name).to(beNil())
             }
         }
     }
@@ -239,7 +243,7 @@ class SWXMLHashLazyTests: QuickSpec {
 class SWXMLHashConfigSpecs: QuickSpec {
     override func spec() {
         describe("optional configuration options for NSXMLParser") {
-            var parser = XMLIndexer("not set")
+            var parser: XMLIndexer?
             let xmlWithNamespace = "<root xmlns:h=\"http://www.w3.org/TR/html4/\"" +
                 "  xmlns:f=\"http://www.w3schools.com/furniture\">" +
                 "  <h:table>" +
@@ -257,7 +261,7 @@ class SWXMLHashConfigSpecs: QuickSpec {
             }
 
             it("should allow processing namespaces or not") {
-                expect(parser["root"]["table"]["tr"]["td"][0].element?.text).to(equal("Apples"))
+                expect(parser!["root"]["table"]["tr"]["td"][0].element?.text).to(equal("Apples"))
             }
         }
     }


### PR DESCRIPTION
I’ve made a few changes to support Swift 2’s new error handling.
The XMLIndexer now has a new enum called XMLIndexerError. This is a
printable enum with different cases for different errors (Attribute,
Key, Index…).
The old XMLIndexer.Error case now takes an XMLIndexerError as
associated type.
if possible this old case got replaced by trowing an error.
Unfortunately subscripts can’t throw yet, because of that the index and
key subscript of XMLIndexer return an .Error(XMLIndexerError).
But I’ve added a key(String) and idx(Int) function which do the same as
the subscripts and throw.

To avoid catching at every XMLIndexer initialisation I’ve added two new
inits in XMLIndexer: one takes an XMLElement and the other a
LazyXMLParser. Both can’t fail.
The old init(AnyObject) throws an XMLIndexerError.Init and should
probably be deprecated.

The new error handling would look something like this.

```swift
do {
     return try xml.key("what").key("subelement").idx(5).key("no match")
} catch XMLIndexer.XMLIndexerError.Key(let key) {
    //handle wrong key
} catch XMLIndexer.XMLIndexerError.Index(let idx) {
   //handle wrong index
} catch let indexerError as XMLIndexer.XMLIndexerError {
   //handle any other XMLIndexerError
}  catch {
   //handle any other error (like default case)
}
```