### PR TITLE
Update to Swift 2.0 on XCode 7 Beta 6

### DIFF
--- a/Source/SWXMLHash.swift
+++ b/Source/SWXMLHash.swift
@@ -485,10 +485,11 @@ extension XMLIndexer: CustomStringConvertible {
     public var description: String {
         switch self {
         case .List(let list):
-            return "\n".join(list.map { $0.description })
+            
+            return list.map { $0.description }.joinWithSeparator("\n")
         case .Element(let elem):
             if elem.name == rootElementName {
-                return "\n".join(elem.children.map { $0.description })
+                return elem.children.map { $0.description }.joinWithSeparator("\n")
             }
 
             return elem.description
@@ -557,7 +558,7 @@ extension XMLElement: CustomStringConvertible {
             }
         }
 
-        var attributesString = " ".join(attributesStringList)
+        var attributesString = attributesStringList.joinWithSeparator(" ")
         if !attributesString.isEmpty {
             attributesString = " " + attributesString
         }
@@ -569,7 +570,7 @@ extension XMLElement: CustomStringConvertible {
                 xmlReturn.append(child.description)
             }
             xmlReturn.append("</\(name)>")
-            return "\n".join(xmlReturn)
+            return xmlReturn.joinWithSeparator("\n")
         }
 
         if text != nil {

--- a/Tests/SWXMLHashSpecs.swift
+++ b/Tests/SWXMLHashSpecs.swift
@@ -53,7 +53,7 @@ class SWXMLHashTests: QuickSpec {
             }
 
             it("should be able to iterate element groups") {
-                expect(", ".join(xml["root"]["catalog"]["book"].all.map { $0["genre"].element!.text! })).to(equal("Computer, Fantasy, Fantasy"))
+                expect(xml["root"]["catalog"]["book"].all.map { $0["genre"].element!.text! }).joinWithSeparator(", ").to(equal("Computer, Fantasy, Fantasy"))
             }
 
             it("should be able to iterate element groups even if only one element is found") {
@@ -85,7 +85,7 @@ class SWXMLHashTests: QuickSpec {
                 let interleavedXml = "<html><body><p>one</p><div>two</div><p>three</p><div>four</div></body></html>"
                 let parsed = SWXMLHash.parse(interleavedXml)
 
-                expect(", ".join(parsed["html"]["body"].children.map{ $0.element!.text! })).to(equal("one, two, three, four"))
+                expect(parsed["html"]["body"].children.map{ $0.element!.text! }).joinWithSeparator(", ").to(equal("one, two, three, four"))
             }
 
             it("should be able to provide a description for the document") {
@@ -173,7 +173,7 @@ class SWXMLHashLazyTests: QuickSpec {
             }
 
             it("should be able to iterate element groups") {
-                expect(", ".join(xml["root"]["catalog"]["book"].all.map { $0["genre"].element?.text ?? "" })).to(equal("Computer, Fantasy, Fantasy"))
+                expect(xml["root"]["catalog"]["book"].all.map { $0["genre"].element?.text ?? "" }).joinWithSeparator(", ").to(equal("Computer, Fantasy, Fantasy"))
             }
 
             it("should be able to iterate element groups even if only one element is found") {
@@ -194,7 +194,7 @@ class SWXMLHashLazyTests: QuickSpec {
             }
 
             it("should be able to enumerate children") {
-                expect(", ".join(xml["root"]["catalog"]["book"][0].children.map{ $0.element?.name ?? "" })).to(equal("author, title, genre, price, publish_date, description"))
+                expect(xml["root"]["catalog"]["book"][0].children.map{ $0.element?.name ?? "" }).joinWithSeparator(", ").to(equal("author, title, genre, price, publish_date, description"))
             }
 
             it("should be able to handle mixed content") {
@@ -205,7 +205,7 @@ class SWXMLHashLazyTests: QuickSpec {
                 let interleavedXml = "<html><body><p>one</p><div>two</div><p>three</p><div>four</div></body></html>"
                 let parsed = SWXMLHash.lazy(interleavedXml)
 
-                expect(", ".join(parsed["html"]["body"].children.map{ $0.element?.text ?? "" })).to(equal("one, two, three, four"))
+                expect(parsed["html"]["body"].children.map{ $0.element?.text ?? "" }).joinWithSeparator(", ").to(equal("one, two, three, four"))
             }
         }
 


### PR DESCRIPTION
convert string.join(collection) to new collection.joinWithSeparator(string) for Xcode 7 beta 6