### PR TITLE
Cleanup: use existing local variable

### DIFF
--- a/Source/SWXMLHash.swift
+++ b/Source/SWXMLHash.swift
@@ -179,7 +179,7 @@ class LazyXMLParser: NSObject, SimpleXmlParser, NSXMLParserDelegate {
             current.text = ""
         }
 
-        parentStack.top().text! += string
+        current.text! += string
     }
 
     func parser(parser: NSXMLParser, didEndElement elementName: String, namespaceURI: String?, qualifiedName qName: String?) {
@@ -241,7 +241,7 @@ class XMLParser: NSObject, SimpleXmlParser, NSXMLParserDelegate {
             current.text = ""
         }
 
-        parentStack.top().text! += string
+        current.text! += string
     }
 
     func parser(parser: NSXMLParser, didEndElement elementName: String, namespaceURI: String?, qualifiedName qName: String?) {


### PR DESCRIPTION
I didn't run unit tests because Carthage installation fails on 10.11 using brew. But the change is straightforward and shouldn't cause any problems.