### PR TITLE
Add explicit tvOS and watchOS targets

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,2 @@
-github "Quick/Quick" "xcode7.1"
-github "Quick/Nimble" "xcode7.1"
+github "Quick/Quick"
+github "Quick/Nimble"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "Quick/Nimble" "3646ed5025f5eae080a98f4a1b3ca0cce775cbc8"
-github "Quick/Quick" "d1d795e58d0f972e8acacaee62a83d4b86db11dd"
+github "Quick/Nimble" "v3.0.0"
+github "Quick/Quick" "v0.8.0"

--- a/SWXMLHash.xcodeproj/project.pbxproj
+++ b/SWXMLHash.xcodeproj/project.pbxproj
@@ -7,6 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		CD291F1C1BF635B3009A1FA6 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD291F1A1BF635B3009A1FA6 /* Nimble.framework */; };
+		CD291F1D1BF635B3009A1FA6 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD291F1B1BF635B3009A1FA6 /* Quick.framework */; };
+		CD291F201BF63613009A1FA6 /* Nimble.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = CD291F1A1BF635B3009A1FA6 /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		CD291F211BF63613009A1FA6 /* Quick.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = CD291F1B1BF635B3009A1FA6 /* Quick.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		CD291F221BF6365A009A1FA6 /* test.xml in Resources */ = {isa = PBXBuildFile; fileRef = CD4B5F3919E2C42D005C1F33 /* test.xml */; };
 		CD4B5F3A19E2C42D005C1F33 /* test.xml in Resources */ = {isa = PBXBuildFile; fileRef = CD4B5F3919E2C42D005C1F33 /* test.xml */; };
 		CD6083F5196CA106000B4F8D /* SWXMLHash.h in Headers */ = {isa = PBXBuildFile; fileRef = CD6083F4196CA106000B4F8D /* SWXMLHash.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CD6083FB196CA106000B4F8D /* SWXMLHash.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD6083EF196CA106000B4F8D /* SWXMLHash.framework */; };
@@ -21,6 +26,10 @@
 		CDC7F3401B0ACCE4006BF6E7 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CDC7F33E1B0ACCE4006BF6E7 /* Quick.framework */; };
 		CDC7F3431B0ACCF4006BF6E7 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CDC7F3411B0ACCF4006BF6E7 /* Nimble.framework */; };
 		CDC7F3441B0ACCF4006BF6E7 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CDC7F3421B0ACCF4006BF6E7 /* Quick.framework */; };
+		CDDEC7561BF6311B00AB138B /* SWXMLHash.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CDDEC74C1BF6311A00AB138B /* SWXMLHash.framework */; };
+		CDDEC7701BF632D200AB138B /* SWXMLHash.h in Headers */ = {isa = PBXBuildFile; fileRef = CD6083F4196CA106000B4F8D /* SWXMLHash.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CDDEC7711BF632DD00AB138B /* SWXMLHash.h in Headers */ = {isa = PBXBuildFile; fileRef = CD6083F4196CA106000B4F8D /* SWXMLHash.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CDDEC7721BF632F300AB138B /* SWXMLHashSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD608401196CA106000B4F8D /* SWXMLHashSpecs.swift */; };
 		CDEB51801B0ACDCD00966541 /* Nimble.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = CDC7F3411B0ACCF4006BF6E7 /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CDEB51811B0ACDCD00966541 /* Quick.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = CDC7F3421B0ACCF4006BF6E7 /* Quick.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CDEB51831B0ACDDD00966541 /* Nimble.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = CDC7F33D1B0ACCE4006BF6E7 /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -42,9 +51,27 @@
 			remoteGlobalIDString = CD9D052B1A757D8B003CCB21;
 			remoteInfo = SWXMLHashOSX;
 		};
+		CDDEC7571BF6311B00AB138B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CD6083E6196CA106000B4F8D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CDDEC74B1BF6311A00AB138B;
+			remoteInfo = SWXMLHash;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		CD291F1F1BF63602009A1FA6 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				CD291F201BF63613009A1FA6 /* Nimble.framework in CopyFiles */,
+				CD291F211BF63613009A1FA6 /* Quick.framework in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		CDEB517F1B0ACDBA00966541 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -70,21 +97,26 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		CD291F1A1BF635B3009A1FA6 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = ../Carthage/Build/tvOS/Nimble.framework; sourceTree = "<group>"; };
+		CD291F1B1BF635B3009A1FA6 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = ../Carthage/Build/tvOS/Quick.framework; sourceTree = "<group>"; };
 		CD4B5F3919E2C42D005C1F33 /* test.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; name = test.xml; path = Tests/test.xml; sourceTree = SOURCE_ROOT; };
 		CD6083EF196CA106000B4F8D /* SWXMLHash.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SWXMLHash.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CD6083F3196CA106000B4F8D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		CD6083F4196CA106000B4F8D /* SWXMLHash.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SWXMLHash.h; sourceTree = "<group>"; };
-		CD6083FA196CA106000B4F8D /* SWXMLHashTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SWXMLHashTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		CD6083FA196CA106000B4F8D /* SWXMLHash iOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SWXMLHash iOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CD608400196CA106000B4F8D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		CD608401196CA106000B4F8D /* SWXMLHashSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SWXMLHashSpecs.swift; sourceTree = "<group>"; };
 		CD60840B196CA11D000B4F8D /* SWXMLHash.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SWXMLHash.swift; sourceTree = "<group>"; };
 		CD9D052C1A757D8B003CCB21 /* SWXMLHash.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SWXMLHash.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		CD9D05361A757D8B003CCB21 /* SWXMLHashOSXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SWXMLHashOSXTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		CD9D05361A757D8B003CCB21 /* SWXMLHash OSX Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SWXMLHash OSX Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CDC7F33D1B0ACCE4006BF6E7 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/Mac/Nimble.framework; sourceTree = SOURCE_ROOT; };
 		CDC7F33E1B0ACCE4006BF6E7 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/Mac/Quick.framework; sourceTree = SOURCE_ROOT; };
 		CDC7F3411B0ACCF4006BF6E7 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/iOS/Nimble.framework; sourceTree = SOURCE_ROOT; };
 		CDC7F3421B0ACCF4006BF6E7 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/iOS/Quick.framework; sourceTree = SOURCE_ROOT; };
 		CDD367381A2584A400807984 /* SWXMLHashPlayground.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = SWXMLHashPlayground.playground; sourceTree = "<group>"; };
+		CDDEC74C1BF6311A00AB138B /* SWXMLHash.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SWXMLHash.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		CDDEC7551BF6311B00AB138B /* SWXMLHash tvOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SWXMLHash tvOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		CDDEC7681BF6316C00AB138B /* SWXMLHash.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SWXMLHash.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -122,9 +154,42 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		CDDEC7481BF6311A00AB138B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CDDEC7521BF6311B00AB138B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CD291F1C1BF635B3009A1FA6 /* Nimble.framework in Frameworks */,
+				CD291F1D1BF635B3009A1FA6 /* Quick.framework in Frameworks */,
+				CDDEC7561BF6311B00AB138B /* SWXMLHash.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CDDEC7641BF6316C00AB138B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		CD291F1E1BF635BE009A1FA6 /* tvOS */ = {
+			isa = PBXGroup;
+			children = (
+				CD291F1A1BF635B3009A1FA6 /* Nimble.framework */,
+				CD291F1B1BF635B3009A1FA6 /* Quick.framework */,
+			);
+			name = tvOS;
+			sourceTree = "<group>";
+		};
 		CD6083E5196CA106000B4F8D = {
 			isa = PBXGroup;
 			children = (
@@ -139,9 +204,12 @@
 			isa = PBXGroup;
 			children = (
 				CD6083EF196CA106000B4F8D /* SWXMLHash.framework */,
-				CD6083FA196CA106000B4F8D /* SWXMLHashTests.xctest */,
+				CD6083FA196CA106000B4F8D /* SWXMLHash iOS Tests.xctest */,
 				CD9D052C1A757D8B003CCB21 /* SWXMLHash.framework */,
-				CD9D05361A757D8B003CCB21 /* SWXMLHashOSXTests.xctest */,
+				CD9D05361A757D8B003CCB21 /* SWXMLHash OSX Tests.xctest */,
+				CDDEC74C1BF6311A00AB138B /* SWXMLHash.framework */,
+				CDDEC7551BF6311B00AB138B /* SWXMLHash tvOS Tests.xctest */,
+				CDDEC7681BF6316C00AB138B /* SWXMLHash.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -167,11 +235,12 @@
 		CD6083FE196CA106000B4F8D /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				CDC7F33C1B0ACC98006BF6E7 /* OSX */,
+				CD291F1E1BF635BE009A1FA6 /* tvOS */,
 				CDC7F33B1B0ACC90006BF6E7 /* iOS */,
+				CDC7F33C1B0ACC98006BF6E7 /* OSX */,
+				CD6083FF196CA106000B4F8D /* Supporting Files */,
 				CD608401196CA106000B4F8D /* SWXMLHashSpecs.swift */,
 				CD4B5F3919E2C42D005C1F33 /* test.xml */,
-				CD6083FF196CA106000B4F8D /* Supporting Files */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -221,12 +290,28 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		CDDEC7491BF6311A00AB138B /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CDDEC7701BF632D200AB138B /* SWXMLHash.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CDDEC7651BF6316C00AB138B /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CDDEC7711BF632DD00AB138B /* SWXMLHash.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		CD6083EE196CA106000B4F8D /* SWXMLHash */ = {
+		CD6083EE196CA106000B4F8D /* SWXMLHash iOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CD608405196CA106000B4F8D /* Build configuration list for PBXNativeTarget "SWXMLHash" */;
+			buildConfigurationList = CD608405196CA106000B4F8D /* Build configuration list for PBXNativeTarget "SWXMLHash iOS" */;
 			buildPhases = (
 				CD6083EA196CA106000B4F8D /* Sources */,
 				CD6083EB196CA106000B4F8D /* Frameworks */,
@@ -237,14 +322,14 @@
 			);
 			dependencies = (
 			);
-			name = SWXMLHash;
+			name = "SWXMLHash iOS";
 			productName = SWXMLHash;
 			productReference = CD6083EF196CA106000B4F8D /* SWXMLHash.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		CD6083F9196CA106000B4F8D /* SWXMLHashTests */ = {
+		CD6083F9196CA106000B4F8D /* SWXMLHash iOS Tests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CD608408196CA106000B4F8D /* Build configuration list for PBXNativeTarget "SWXMLHashTests" */;
+			buildConfigurationList = CD608408196CA106000B4F8D /* Build configuration list for PBXNativeTarget "SWXMLHash iOS Tests" */;
 			buildPhases = (
 				CD6083F6196CA106000B4F8D /* Sources */,
 				CD6083F7196CA106000B4F8D /* Frameworks */,
@@ -256,14 +341,14 @@
 			dependencies = (
 				CD6083FD196CA106000B4F8D /* PBXTargetDependency */,
 			);
-			name = SWXMLHashTests;
+			name = "SWXMLHash iOS Tests";
 			productName = SWXMLHashTests;
-			productReference = CD6083FA196CA106000B4F8D /* SWXMLHashTests.xctest */;
+			productReference = CD6083FA196CA106000B4F8D /* SWXMLHash iOS Tests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		CD9D052B1A757D8B003CCB21 /* SWXMLHashOSX */ = {
+		CD9D052B1A757D8B003CCB21 /* SWXMLHash OSX */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CD9D053F1A757D8B003CCB21 /* Build configuration list for PBXNativeTarget "SWXMLHashOSX" */;
+			buildConfigurationList = CD9D053F1A757D8B003CCB21 /* Build configuration list for PBXNativeTarget "SWXMLHash OSX" */;
 			buildPhases = (
 				CD9D05271A757D8B003CCB21 /* Sources */,
 				CD9D05281A757D8B003CCB21 /* Frameworks */,
@@ -274,14 +359,14 @@
 			);
 			dependencies = (
 			);
-			name = SWXMLHashOSX;
+			name = "SWXMLHash OSX";
 			productName = SWXMLHashOSX;
 			productReference = CD9D052C1A757D8B003CCB21 /* SWXMLHash.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		CD9D05351A757D8B003CCB21 /* SWXMLHashOSXTests */ = {
+		CD9D05351A757D8B003CCB21 /* SWXMLHash OSX Tests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CD9D05421A757D8B003CCB21 /* Build configuration list for PBXNativeTarget "SWXMLHashOSXTests" */;
+			buildConfigurationList = CD9D05421A757D8B003CCB21 /* Build configuration list for PBXNativeTarget "SWXMLHash OSX Tests" */;
 			buildPhases = (
 				CD9D05321A757D8B003CCB21 /* Sources */,
 				CD9D05331A757D8B003CCB21 /* Frameworks */,
@@ -293,10 +378,65 @@
 			dependencies = (
 				CD9D05391A757D8B003CCB21 /* PBXTargetDependency */,
 			);
-			name = SWXMLHashOSXTests;
+			name = "SWXMLHash OSX Tests";
 			productName = SWXMLHashOSXTests;
-			productReference = CD9D05361A757D8B003CCB21 /* SWXMLHashOSXTests.xctest */;
+			productReference = CD9D05361A757D8B003CCB21 /* SWXMLHash OSX Tests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		CDDEC74B1BF6311A00AB138B /* SWXMLHash tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CDDEC75D1BF6311B00AB138B /* Build configuration list for PBXNativeTarget "SWXMLHash tvOS" */;
+			buildPhases = (
+				CDDEC7471BF6311A00AB138B /* Sources */,
+				CDDEC7481BF6311A00AB138B /* Frameworks */,
+				CDDEC7491BF6311A00AB138B /* Headers */,
+				CDDEC74A1BF6311A00AB138B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "SWXMLHash tvOS";
+			productName = SWXMLHash;
+			productReference = CDDEC74C1BF6311A00AB138B /* SWXMLHash.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		CDDEC7541BF6311B00AB138B /* SWXMLHash tvOS Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CDDEC7601BF6311B00AB138B /* Build configuration list for PBXNativeTarget "SWXMLHash tvOS Tests" */;
+			buildPhases = (
+				CDDEC7511BF6311B00AB138B /* Sources */,
+				CDDEC7521BF6311B00AB138B /* Frameworks */,
+				CDDEC7531BF6311B00AB138B /* Resources */,
+				CD291F1F1BF63602009A1FA6 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				CDDEC7581BF6311B00AB138B /* PBXTargetDependency */,
+			);
+			name = "SWXMLHash tvOS Tests";
+			productName = SWXMLHashTests;
+			productReference = CDDEC7551BF6311B00AB138B /* SWXMLHash tvOS Tests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		CDDEC7671BF6316C00AB138B /* SWXMLHash watchOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CDDEC76D1BF6316C00AB138B /* Build configuration list for PBXNativeTarget "SWXMLHash watchOS" */;
+			buildPhases = (
+				CDDEC7631BF6316C00AB138B /* Sources */,
+				CDDEC7641BF6316C00AB138B /* Frameworks */,
+				CDDEC7651BF6316C00AB138B /* Headers */,
+				CDDEC7661BF6316C00AB138B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "SWXMLHash watchOS";
+			productName = SWXMLHash;
+			productReference = CDDEC7681BF6316C00AB138B /* SWXMLHash.framework */;
+			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
 
@@ -304,7 +444,7 @@
 		CD6083E6196CA106000B4F8D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0700;
+				LastSwiftUpdateCheck = 0710;
 				LastUpgradeCheck = 0700;
 				TargetAttributes = {
 					CD6083EE196CA106000B4F8D = {
@@ -320,6 +460,15 @@
 					CD9D05351A757D8B003CCB21 = {
 						CreatedOnToolsVersion = 6.1.1;
 					};
+					CDDEC74B1BF6311A00AB138B = {
+						CreatedOnToolsVersion = 7.1.1;
+					};
+					CDDEC7541BF6311B00AB138B = {
+						CreatedOnToolsVersion = 7.1.1;
+					};
+					CDDEC7671BF6316C00AB138B = {
+						CreatedOnToolsVersion = 7.1.1;
+					};
 				};
 			};
 			buildConfigurationList = CD6083E9196CA106000B4F8D /* Build configuration list for PBXProject "SWXMLHash" */;
@@ -334,10 +483,13 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				CD6083EE196CA106000B4F8D /* SWXMLHash */,
-				CD9D052B1A757D8B003CCB21 /* SWXMLHashOSX */,
-				CD6083F9196CA106000B4F8D /* SWXMLHashTests */,
-				CD9D05351A757D8B003CCB21 /* SWXMLHashOSXTests */,
+				CD6083EE196CA106000B4F8D /* SWXMLHash iOS */,
+				CD6083F9196CA106000B4F8D /* SWXMLHash iOS Tests */,
+				CD9D052B1A757D8B003CCB21 /* SWXMLHash OSX */,
+				CD9D05351A757D8B003CCB21 /* SWXMLHash OSX Tests */,
+				CDDEC74B1BF6311A00AB138B /* SWXMLHash tvOS */,
+				CDDEC7541BF6311B00AB138B /* SWXMLHash tvOS Tests */,
+				CDDEC7671BF6316C00AB138B /* SWXMLHash watchOS */,
 			);
 		};
 /* End PBXProject section */
@@ -370,6 +522,28 @@
 			buildActionMask = 2147483647;
 			files = (
 				CD7934C41A7581E600867857 /* test.xml in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CDDEC74A1BF6311A00AB138B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CDDEC7531BF6311B00AB138B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CD291F221BF6365A009A1FA6 /* test.xml in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CDDEC7661BF6316C00AB138B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -408,18 +582,45 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		CDDEC7471BF6311A00AB138B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CDDEC7511BF6311B00AB138B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CDDEC7721BF632F300AB138B /* SWXMLHashSpecs.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CDDEC7631BF6316C00AB138B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
 		CD6083FD196CA106000B4F8D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = CD6083EE196CA106000B4F8D /* SWXMLHash */;
+			target = CD6083EE196CA106000B4F8D /* SWXMLHash iOS */;
 			targetProxy = CD6083FC196CA106000B4F8D /* PBXContainerItemProxy */;
 		};
 		CD9D05391A757D8B003CCB21 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = CD9D052B1A757D8B003CCB21 /* SWXMLHashOSX */;
+			target = CD9D052B1A757D8B003CCB21 /* SWXMLHash OSX */;
 			targetProxy = CD9D05381A757D8B003CCB21 /* PBXContainerItemProxy */;
+		};
+		CDDEC7581BF6311B00AB138B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = CDDEC74B1BF6311A00AB138B /* SWXMLHash tvOS */;
+			targetProxy = CDDEC7571BF6311B00AB138B /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -526,7 +727,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "drmohundro.$(PRODUCT_NAME:rfc1034identifier)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = SWXMLHash;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
@@ -548,7 +749,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "drmohundro.$(PRODUCT_NAME:rfc1034identifier)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = SWXMLHash;
 				SKIP_INSTALL = YES;
 			};
 			name = Release;
@@ -679,6 +880,131 @@
 			};
 			name = Release;
 		};
+		CDDEC75E1BF6311B00AB138B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/Source/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = drmohundro.SWXMLHash;
+				PRODUCT_NAME = SWXMLHash;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Debug;
+		};
+		CDDEC75F1BF6311B00AB138B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/Source/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = drmohundro.SWXMLHash;
+				PRODUCT_NAME = SWXMLHash;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Release;
+		};
+		CDDEC7611BF6311B00AB138B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/tvOS",
+				);
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = Tests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "drmohundro.SWXMLHash-tvOS-Tests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Debug;
+		};
+		CDDEC7621BF6311B00AB138B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/tvOS",
+				);
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = Tests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "drmohundro.SWXMLHash-tvOS-Tests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Release;
+		};
+		CDDEC76E1BF6316C00AB138B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/Source/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = drmohundro.SWXMLHash;
+				PRODUCT_NAME = SWXMLHash;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		CDDEC76F1BF6316C00AB138B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/Source/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = drmohundro.SWXMLHash;
+				PRODUCT_NAME = SWXMLHash;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -691,7 +1017,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		CD608405196CA106000B4F8D /* Build configuration list for PBXNativeTarget "SWXMLHash" */ = {
+		CD608405196CA106000B4F8D /* Build configuration list for PBXNativeTarget "SWXMLHash iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				CD608406196CA106000B4F8D /* Debug */,
@@ -700,7 +1026,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		CD608408196CA106000B4F8D /* Build configuration list for PBXNativeTarget "SWXMLHashTests" */ = {
+		CD608408196CA106000B4F8D /* Build configuration list for PBXNativeTarget "SWXMLHash iOS Tests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				CD608409196CA106000B4F8D /* Debug */,
@@ -709,7 +1035,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		CD9D053F1A757D8B003CCB21 /* Build configuration list for PBXNativeTarget "SWXMLHashOSX" */ = {
+		CD9D053F1A757D8B003CCB21 /* Build configuration list for PBXNativeTarget "SWXMLHash OSX" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				CD9D05401A757D8B003CCB21 /* Debug */,
@@ -718,11 +1044,38 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		CD9D05421A757D8B003CCB21 /* Build configuration list for PBXNativeTarget "SWXMLHashOSXTests" */ = {
+		CD9D05421A757D8B003CCB21 /* Build configuration list for PBXNativeTarget "SWXMLHash OSX Tests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				CD9D05431A757D8B003CCB21 /* Debug */,
 				CD9D05441A757D8B003CCB21 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CDDEC75D1BF6311B00AB138B /* Build configuration list for PBXNativeTarget "SWXMLHash tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CDDEC75E1BF6311B00AB138B /* Debug */,
+				CDDEC75F1BF6311B00AB138B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CDDEC7601BF6311B00AB138B /* Build configuration list for PBXNativeTarget "SWXMLHash tvOS Tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CDDEC7611BF6311B00AB138B /* Debug */,
+				CDDEC7621BF6311B00AB138B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CDDEC76D1BF6316C00AB138B /* Build configuration list for PBXNativeTarget "SWXMLHash watchOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CDDEC76E1BF6316C00AB138B /* Debug */,
+				CDDEC76F1BF6316C00AB138B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/SWXMLHash.xcodeproj/xcshareddata/xcschemes/SWXMLHash OSX.xcscheme
+++ b/SWXMLHash.xcodeproj/xcshareddata/xcschemes/SWXMLHash OSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0710"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -16,39 +16,25 @@
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "CD9D052B1A757D8B003CCB21"
                BuildableName = "SWXMLHash.framework"
-               BlueprintName = "SWXMLHashOSX"
-               ReferencedContainer = "container:SWXMLHash.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "NO"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "CD9D05351A757D8B003CCB21"
-               BuildableName = "SWXMLHashOSXTests.xctest"
-               BlueprintName = "SWXMLHashOSXTests"
+               BlueprintName = "SWXMLHash OSX"
                ReferencedContainer = "container:SWXMLHash.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "CD9D05351A757D8B003CCB21"
-               BuildableName = "SWXMLHashOSXTests.xctest"
-               BlueprintName = "SWXMLHashOSXTests"
+               BuildableName = "SWXMLHash OSX Tests.xctest"
+               BlueprintName = "SWXMLHash OSX Tests"
                ReferencedContainer = "container:SWXMLHash.xcodeproj">
             </BuildableReference>
          </TestableReference>
@@ -58,7 +44,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "CD9D052B1A757D8B003CCB21"
             BuildableName = "SWXMLHash.framework"
-            BlueprintName = "SWXMLHashOSX"
+            BlueprintName = "SWXMLHash OSX"
             ReferencedContainer = "container:SWXMLHash.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -66,11 +52,11 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
@@ -80,7 +66,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "CD9D052B1A757D8B003CCB21"
             BuildableName = "SWXMLHash.framework"
-            BlueprintName = "SWXMLHashOSX"
+            BlueprintName = "SWXMLHash OSX"
             ReferencedContainer = "container:SWXMLHash.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -88,17 +74,17 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "CD9D052B1A757D8B003CCB21"
             BuildableName = "SWXMLHash.framework"
-            BlueprintName = "SWXMLHashOSX"
+            BlueprintName = "SWXMLHash OSX"
             ReferencedContainer = "container:SWXMLHash.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/SWXMLHash.xcodeproj/xcshareddata/xcschemes/SWXMLHash iOS.xcscheme
+++ b/SWXMLHash.xcodeproj/xcshareddata/xcschemes/SWXMLHash iOS.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0710"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CD6083EE196CA106000B4F8D"
+               BuildableName = "SWXMLHash.framework"
+               BlueprintName = "SWXMLHash iOS"
+               ReferencedContainer = "container:SWXMLHash.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CD6083F9196CA106000B4F8D"
+               BuildableName = "SWXMLHash iOS Tests.xctest"
+               BlueprintName = "SWXMLHash iOS Tests"
+               ReferencedContainer = "container:SWXMLHash.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CD6083EE196CA106000B4F8D"
+            BuildableName = "SWXMLHash.framework"
+            BlueprintName = "SWXMLHash iOS"
+            ReferencedContainer = "container:SWXMLHash.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CD6083EE196CA106000B4F8D"
+            BuildableName = "SWXMLHash.framework"
+            BlueprintName = "SWXMLHash iOS"
+            ReferencedContainer = "container:SWXMLHash.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CD6083EE196CA106000B4F8D"
+            BuildableName = "SWXMLHash.framework"
+            BlueprintName = "SWXMLHash iOS"
+            ReferencedContainer = "container:SWXMLHash.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SWXMLHash.xcodeproj/xcshareddata/xcschemes/SWXMLHash tvOS.xcscheme
+++ b/SWXMLHash.xcodeproj/xcshareddata/xcschemes/SWXMLHash tvOS.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0710"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CDDEC74B1BF6311A00AB138B"
+               BuildableName = "SWXMLHash.framework"
+               BlueprintName = "SWXMLHash tvOS"
+               ReferencedContainer = "container:SWXMLHash.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CDDEC7541BF6311B00AB138B"
+               BuildableName = "SWXMLHash tvOS Tests.xctest"
+               BlueprintName = "SWXMLHash tvOS Tests"
+               ReferencedContainer = "container:SWXMLHash.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CDDEC74B1BF6311A00AB138B"
+            BuildableName = "SWXMLHash.framework"
+            BlueprintName = "SWXMLHash tvOS"
+            ReferencedContainer = "container:SWXMLHash.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CDDEC74B1BF6311A00AB138B"
+            BuildableName = "SWXMLHash.framework"
+            BlueprintName = "SWXMLHash tvOS"
+            ReferencedContainer = "container:SWXMLHash.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CDDEC74B1BF6311A00AB138B"
+            BuildableName = "SWXMLHash.framework"
+            BlueprintName = "SWXMLHash tvOS"
+            ReferencedContainer = "container:SWXMLHash.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SWXMLHash.xcodeproj/xcshareddata/xcschemes/SWXMLHash watchOS.xcscheme
+++ b/SWXMLHash.xcodeproj/xcshareddata/xcschemes/SWXMLHash watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0710"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,63 +14,30 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "CD6083EE196CA106000B4F8D"
+               BlueprintIdentifier = "CDDEC7671BF6316C00AB138B"
                BuildableName = "SWXMLHash.framework"
-               BlueprintName = "SWXMLHash"
-               ReferencedContainer = "container:SWXMLHash.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "NO"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "CD6083F9196CA106000B4F8D"
-               BuildableName = "SWXMLHashTests.xctest"
-               BlueprintName = "SWXMLHashTests"
+               BlueprintName = "SWXMLHash watchOS"
                ReferencedContainer = "container:SWXMLHash.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "CD6083F9196CA106000B4F8D"
-               BuildableName = "SWXMLHashTests.xctest"
-               BlueprintName = "SWXMLHashTests"
-               ReferencedContainer = "container:SWXMLHash.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "CD6083EE196CA106000B4F8D"
-            BuildableName = "SWXMLHash.framework"
-            BlueprintName = "SWXMLHash"
-            ReferencedContainer = "container:SWXMLHash.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
@@ -78,9 +45,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "CD6083EE196CA106000B4F8D"
+            BlueprintIdentifier = "CDDEC7671BF6316C00AB138B"
             BuildableName = "SWXMLHash.framework"
-            BlueprintName = "SWXMLHash"
+            BlueprintName = "SWXMLHash watchOS"
             ReferencedContainer = "container:SWXMLHash.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -88,17 +55,17 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "CD6083EE196CA106000B4F8D"
+            BlueprintIdentifier = "CDDEC7671BF6316C00AB138B"
             BuildableName = "SWXMLHash.framework"
-            BlueprintName = "SWXMLHash"
+            BlueprintName = "SWXMLHash watchOS"
             ReferencedContainer = "container:SWXMLHash.xcodeproj">
          </BuildableReference>
       </MacroExpansion>


### PR DESCRIPTION
I had already added tvOS and watchOS CocoaPods support, but additional targets are necessary for Carthage support. I cleaned up some of the existing targets and renamed them to make it more clear what their purpose is.

This will resolve #54.