### PR TITLE
Add specs and support for mixed content

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,16 +4,15 @@ end
 
 desc 'Clean, build and test SWXMLHash'
 task :test do |t|
-  #xctool_build_cmd = './scripts/build.sh'
-  xcode_build_cmd = 'xcodebuild -workspace SWXMLHash.xcworkspace -scheme SWXMLHash clean build test -sdk iphonesimulator'
+  xctool_build_cmd = './scripts/build.sh'
 
-  #if system('which xctool')
-    #run xctool_build_cmd
-  #else
+  if system('which xctool')
+    run xctool_build_cmd
+  else
     if system('which xcpretty')
       run "#{xcode_build_cmd} | xcpretty -c"
     else
       run xcode_build_cmd
     end
-  #end
+  end
 end

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -2,4 +2,4 @@
 
 set -ev
 
-xctool -scheme SWXMLHash clean build test -sdk iphonesimulator
+xctool -scheme "SWXMLHash iOS" clean build test -sdk iphonesimulator

--- a/Tests/SWXMLHashSpecs.swift
+++ b/Tests/SWXMLHashSpecs.swift
@@ -95,7 +95,7 @@ class SWXMLHashTests: QuickSpec {
                 let descriptionXml = "<root><foo><what id=\"myId\">puppies</what></foo></root>"
                 let parsed = SWXMLHash.parse(descriptionXml)
 
-                expect(parsed.description).to(equal("<root>\n<foo>\n<what id=\"myId\">puppies</what>\n</foo>\n</root>"))
+                expect(parsed.description).to(equal("<root><foo><what id=\"myId\">puppies</what></foo></root>"))
             }
         }
 
@@ -156,6 +156,19 @@ class SWXMLHashTests: QuickSpec {
                     err = nil
                 }
                 expect(err).toNot(beNil())
+            }
+        }
+
+        describe("mixed text with XML elements") {
+            var xml: XMLIndexer?
+
+            beforeEach {
+                let xmlContent = "<everything><news><content>Here is a cool thing <a href=\"google.com\">A</a> and second cool thing <a href=\"fb.com\">B</a></content></news></everything>"
+                xml = SWXMLHash.parse(xmlContent)
+            }
+
+            it("should be able to get all contents inside of an element") {
+                expect(xml!["everything"]["news"]["content"].description).to(equal("<content>Here is a cool thing <a href=\"google.com\">A</a> and second cool thing <a href=\"fb.com\">B</a></content>"))
             }
         }
     }


### PR DESCRIPTION
This commit adds initial support for mixed content (i.e. text + XML inside an element) and should fix issue #33.

To support a variety of text/XML content, the general approach to text had to change - before, text was handled via simple string concatenation. The problem, though, is that this means that an element either has children or text - no options.

Now, there is the concept of both TextElements and XMLElements - both are stored as children of an element. This change should be API backwards compatible.