### PR TITLE
Add support for Bool conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ struct Book: XMLIndexerDeserializable {
     let price: Double
     let year: Int
     let amount: Int?
-    
+
     static func deserialize(node: XMLIndexer) throws -> Book {
         return try Book(
             title: node["title"].value(),
@@ -334,7 +334,7 @@ let books: [Book] = try xml["root"]["books"]["book"].value()
 
 <img src="https://raw.githubusercontent.com/ncreated/SWXMLHash/assets/types-conversion%402x.png" width="600" alt="Types Conversion" />
 
-Build-in, leaf-nodes converters support `Int`, `Double`, `Float` and `String` values (both non- and -optional variants). Custom converters can be added by implementing `XMLElementDeserializable`.
+Build-in, leaf-nodes converters support `Int`, `Double`, `Float`, `Bool`, and `String` values (both non- and -optional variants). Custom converters can be added by implementing `XMLElementDeserializable`.
 
 You can convert any XML to your custom type by implementing `XMLIndexerDeserializable`.
 

--- a/Source/SWXMLHash+TypeConversion.swift
+++ b/Source/SWXMLHash+TypeConversion.swift
@@ -325,3 +325,19 @@ extension Float: XMLElementDeserializable {
         return value
     }
 }
+
+extension Bool: XMLElementDeserializable {
+    /**
+     Attempts to deserialize XML element content to a Bool. This uses NSString's 'boolValue' described
+     [here](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSString_Class/#//apple_ref/occ/instp/NSString/boolValue)
+
+     - parameters:
+     - element: the XMLElement to be deserialized
+     - throws: an XMLDeserializationError.TypeConversionFailed if the element cannot be deserialized
+     - returns: the deserialized Bool value
+     */
+    public static func deserialize(element: XMLElement) throws -> Bool {
+        let value = Bool(NSString(string: try element.nonEmptyTextOrThrow()).boolValue)
+        return value
+    }
+}

--- a/Tests/SWXMLHashSpecs.swift
+++ b/Tests/SWXMLHashSpecs.swift
@@ -312,6 +312,8 @@ class SWXMLHashTypeConversionSpecs: QuickSpec {
                 "  <int>100</int>" +
                 "  <double>100.45</double>" +
                 "  <float>44.12</float>" +
+                "  <bool1>0</bool1>" +
+                "  <bool2>true</bool2>" +
                 "  <empty></empty>" +
                 "  <basicItem>" +
                 "    <name>the name of basic item</name>" +
@@ -457,6 +459,45 @@ class SWXMLHashTypeConversionSpecs: QuickSpec {
 
                 it("should convert `missing` to optional") {
                     let value: Float? = try! parser!["root"]["missing"].value()
+                    expect(value).to(beNil())
+                }
+            }
+
+            describe("when parsing Bool") {
+                it("should convert `value` to non-optional") {
+                    let value1: Bool = try! parser!["root"]["bool1"].value()
+                    let value2: Bool = try! parser!["root"]["bool2"].value()
+                    expect(value1) == false
+                    expect(value2) == true
+                }
+
+                it("should throw when converting `empty` to non-optional") {
+                    expect { try (parser!["root"]["empty"].value() as Bool) }.to(
+                        throwError(errorType: XMLDeserializationError.self)
+                    )
+                }
+
+                it("should throw when converting `missing` to non-optional") {
+                    expect { try (parser!["root"]["missing"].value() as Bool) }.to(
+                        throwError(errorType: XMLDeserializationError.self)
+                    )
+                }
+
+                it("should convert `value` to optional") {
+                    let value1: Bool? = try! parser!["root"]["bool1"].value()
+                    expect(value1) == false
+                    let value2: Bool? = try! parser!["root"]["bool2"].value()
+                    expect(value2) == true
+                }
+
+                it("should convert `empty` to optional") {
+                    expect { try (parser!["root"]["empty"].value() as Bool?) }.to(
+                        throwError(errorType: XMLDeserializationError.self)
+                    )
+                }
+
+                it("should convert `missing` to optional") {
+                    let value: Bool? = try! parser!["root"]["missing"].value()
                     expect(value).to(beNil())
                 }
             }


### PR DESCRIPTION
To add Bool conversion, I followed the pattern that existed for the other types. However, since Swift does not have built-in type conversion to Bool, I made use of the .boolValue member of NSString. This converts any string starting with 't', 'T', 'y', 'Y', or a non-zero integer to 'true' and everything else to 'false'. It does not throw exceptions.