### PR TITLE
Fix build error on Swift Package Manager

### DIFF
--- a/Source/SWXMLHash+TypeConversion.swift
+++ b/Source/SWXMLHash+TypeConversion.swift
@@ -6,6 +6,7 @@
 //
 //
 
+import Foundation
 
 // MARK: - XMLIndexerDeserializable
 


### PR DESCRIPTION
https://travis-ci.org/realm/SwiftLint/jobs/121989579#L499

> SWXMLHash+TypeConversion.swift:341:26: error: use of unresolved identifier 'NSString'
