### PR TITLE
Add Stream handling for serialization

### DIFF
--- a/Source/SWXMLHash+TypeConversion.swift
+++ b/Source/SWXMLHash+TypeConversion.swift
@@ -70,6 +70,8 @@ public extension XMLIndexer {
         switch self {
         case .Element(let element):
             return try T.deserialize(element)
+        case .Stream(let opStream):
+            return try! opStream.findElements().value()
         default:
             throw XMLDeserializationError.NodeIsInvalid(node: self)
         }
@@ -85,6 +87,8 @@ public extension XMLIndexer {
         switch self {
         case .Element(let element):
             return try T.deserialize(element)
+        case .Stream(let opStream):
+            return try! opStream.findElements().value()
         default:
             return nil
         }
@@ -102,6 +106,8 @@ public extension XMLIndexer {
             return try elements.map { try T.deserialize($0) }
         case .Element(let element):
             return try [element].map { try T.deserialize($0) }
+        case .Stream(let opStream):
+            return try! opStream.findElements().value()
         default:
             return []
         }
@@ -119,6 +125,8 @@ public extension XMLIndexer {
             return try elements.map { try T.deserialize($0) }
         case .Element(let element):
             return try [element].map { try T.deserialize($0) }
+        case .Stream(let opStream):
+            return try! opStream.findElements().value()
         default:
             return nil
         }
@@ -136,6 +144,8 @@ public extension XMLIndexer {
             return try elements.map { try T.deserialize($0) }
         case .Element(let element):
             return try [element].map { try T.deserialize($0) }
+        case .Stream(let opStream):
+            return try! opStream.findElements().value()
         default:
             return []
         }
@@ -154,6 +164,8 @@ public extension XMLIndexer {
         switch self {
         case .Element:
             return try T.deserialize(self)
+        case .Stream(let opStream):
+            return try! opStream.findElements().value()
         default:
             throw XMLDeserializationError.NodeIsInvalid(node: self)
         }
@@ -169,6 +181,8 @@ public extension XMLIndexer {
         switch self {
         case .Element:
             return try T.deserialize(self)
+        case .Stream(let opStream):
+            return try! opStream.findElements().value()
         default:
             return nil
         }
@@ -186,6 +200,8 @@ public extension XMLIndexer {
             return try elements.map { try T.deserialize( XMLIndexer($0) ) }
         case .Element(let element):
             return try [element].map { try T.deserialize( XMLIndexer($0) ) }
+        case .Stream(let opStream):
+            return try! opStream.findElements().value()
         default:
             throw XMLDeserializationError.NodeIsInvalid(node: self)
         }
@@ -203,6 +219,8 @@ public extension XMLIndexer {
             return try elements.map { try T.deserialize( XMLIndexer($0) ) }
         case .Element(let element):
             return try [element].map { try T.deserialize( XMLIndexer($0) ) }
+        case .Stream(let opStream):
+            return try! opStream.findElements().value()
         default:
             throw XMLDeserializationError.NodeIsInvalid(node: self)
         }
@@ -220,6 +238,8 @@ public extension XMLIndexer {
             return try elements.map {  try T.deserialize( XMLIndexer($0) ) }
         case .Element(let element):
             return try [element].map { try T.deserialize( XMLIndexer($0) ) }
+        case .Stream(let opStream):
+            return try! opStream.findElements().value()
         default:
             throw XMLDeserializationError.NodeIsInvalid(node: self)
         }

--- a/Source/SWXMLHash.swift
+++ b/Source/SWXMLHash.swift
@@ -413,7 +413,6 @@ public enum XMLIndexer: SequenceType {
     public func withAttr(attr: String, _ value: String) throws -> XMLIndexer {
         switch self {
         case .Stream(let opStream):
-            opStream.stringify()
             let match = opStream.findElements()
             return try match.withAttr(attr, value)
         case .List(let list):

--- a/Tests/SWXMLHashSpecs.swift
+++ b/Tests/SWXMLHashSpecs.swift
@@ -305,6 +305,34 @@ class SWXMLHashConfigSpecs: QuickSpec {
 
 class SWXMLHashTypeConversionSpecs: QuickSpec {
     override func spec() {
+        describe("lazy types conversion") {
+            var parser: XMLIndexer?
+            let xmlWithBasicTypes = "<root>" +
+                "  <string>the string value</string>" +
+                "  <int>100</int>" +
+                "  <double>100.45</double>" +
+                "  <float>44.12</float>" +
+                "  <bool1>0</bool1>" +
+                "  <bool2>true</bool2>" +
+                "  <empty></empty>" +
+                "  <basicItem>" +
+                "    <name>the name of basic item</name>" +
+                "    <price>99.14</price>" +
+                "  </basicItem>" +
+            "</root>"
+
+            beforeEach {
+                parser = SWXMLHash.config { cfg in cfg.shouldProcessLazily = true }.parse(xmlWithBasicTypes)
+            }
+
+            describe("when parsing String") {
+                it("should convert `value` to non-optional") {
+                    let value: String = try! parser!["root"]["string"].value()
+                    expect(value) == "the string value"
+                }
+            }
+        }
+
         describe("basic types conversion") {
             var parser: XMLIndexer?
             let xmlWithBasicTypes = "<root>" +


### PR DESCRIPTION
The serialization support didn't handle the .Stream case which means that lazy loading and serialization didn't work together.

Fixes #79