### PR TITLE
Add XMLAttribute type w/ text deserialization

### DIFF
--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>2.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Source/SWXMLHash.swift
+++ b/Source/SWXMLHash.swift
@@ -416,18 +416,15 @@ public enum XMLIndexer: SequenceType {
             let match = opStream.findElements()
             return try match.withAttr(attr, value)
         case .List(let list):
-            if let elem = list.filter({$0.attributes[attr] == value}).first {
+            if let elem = list.filter({$0.attribute(by: attr)?.text == value}).first {
                 return .Element(elem)
             }
             throw Error.AttributeValue(attr: attr, value: value)
         case .Element(let elem):
-            if let attr = elem.attributes[attr] {
-                if attr == value {
-                    return .Element(elem)
-                }
-                throw Error.AttributeValue(attr: attr, value: value)
+            if elem.attribute(by: attr)?.text == value {
+                return .Element(elem)
             }
-            fallthrough
+            throw Error.AttributeValue(attr: attr, value: value)
         default:
             throw Error.Attribute(attr: attr)
         }
@@ -614,13 +611,22 @@ extension XMLIndexer.Error: CustomStringConvertible {
 }
 
 /// Models content for an XML doc, whether it is text or XML
-public protocol XMLContent: CustomStringConvertible {
-}
+public protocol XMLContent: CustomStringConvertible { }
 
 /// Models a text element
 public class TextElement: XMLContent {
+    /// The underlying text value
     public let text: String
     init(text: String) {
+        self.text = text
+    }
+}
+
+public struct XMLAttribute {
+    public let name: String
+    public let text: String
+    init(name: String, text: String) {
+        self.name = name
         self.text = text
     }
 }
@@ -629,8 +635,16 @@ public class TextElement: XMLContent {
 public class XMLElement: XMLContent {
     /// The name of the element
     public let name: String
+
     /// The attributes of the element
+    @available(*, deprecated, message="See `allAttributes` instead, which introduces the XMLAttribute type over a simple String type")
     public var attributes = [String:String]()
+
+    public var allAttributes = [String:XMLAttribute]()
+
+    public func attribute(by name: String) -> XMLAttribute? {
+        return allAttributes[name]
+    }
 
     /// The inner text of the element, if it exists
     public var text: String? {
@@ -676,8 +690,11 @@ public class XMLElement: XMLContent {
 
         for (keyAny, valueAny) in attributes {
             if let key = keyAny as? String,
-                let value = valueAny as? String {
+                value = valueAny as? String {
+                // TODO: remove this... use new one instead
                 element.attributes[key] = value
+
+                element.allAttributes[key] = XMLAttribute(name: key, text: value)
             }
         }
 
@@ -698,17 +715,17 @@ extension TextElement: CustomStringConvertible {
     }
 }
 
+extension XMLAttribute: CustomStringConvertible {
+    /// The textual representation of an `XMLAttribute` instance.
+    public var description: String {
+        return "\(name)=\"\(text)\""
+    }
+}
+
 extension XMLElement: CustomStringConvertible {
     /// The tag, attributes and content for a `XMLElement` instance (<elem id="foo">content</elem>)
     public var description: String {
-        var attributesStringList = [String]()
-        if !attributes.isEmpty {
-            for (key, val) in attributes {
-                attributesStringList.append("\(key)=\"\(val)\"")
-            }
-        }
-
-        var attributesString = attributesStringList.joinWithSeparator(" ")
+        var attributesString = allAttributes.map { $0.1.description }.joinWithSeparator(" ")
         if !attributesString.isEmpty {
             attributesString = " " + attributesString
         }

--- a/Tests/SWXMLHashSpecs.swift
+++ b/Tests/SWXMLHashSpecs.swift
@@ -52,8 +52,12 @@ class SWXMLHashTests: QuickSpec {
                 expect(xml!["root"]["catalog"]["book"][1]["author"].element?.text).to(equal("Ralls, Kim"))
             }
 
-            it("should be able to parse attributes") {
+            it("should be able to parse attributes (with deprecated approach)") {
                 expect(xml!["root"]["catalog"]["book"][1].element?.attributes["id"]).to(equal("bk102"))
+            }
+
+            it("should be able to parse attributes") {
+                expect(xml!["root"]["catalog"]["book"][1].element!.attribute(by: "id")!.text).to(equal("bk102"))
             }
 
             it("should be able to look up elements by name and attribute") {
@@ -347,6 +351,13 @@ class SWXMLHashTypeConversionSpecs: QuickSpec {
                 "    <name>the name of basic item</name>" +
                 "    <price>99.14</price>" +
                 "  </basicItem>" +
+                "  <attributeElement " +
+                "    stringAttr=\"stringValue\"" +
+                "    intAttr=\"5\"" +
+                "    doubleAttr=\"100.45\"" +
+                "    floatAttr=\"44.12\"" +
+                "    boolAttr=\"false\"" +
+                "  />" +
                 "</root>"
 
             beforeEach {
@@ -565,6 +576,38 @@ class SWXMLHashTypeConversionSpecs: QuickSpec {
                 it("should convert `missing` to optional") {
                     let value: BasicItem? = try! parser!["root"]["missing"].value()
                     expect(value).to(beNil())
+                }
+            }
+
+            describe("when parsing attributes") {
+                it("should parse string values") {
+                    let value: String = parser!["root"]["attributeElement"].element!.attribute(by: "stringAttr")!.value()
+                    expect(value) == "stringValue"
+                }
+
+                it("should parse int values") {
+                    let value: Int = parser!["root"]["attributeElement"].element!.attribute(by: "intAttr")!.value()
+                    expect(value) == 5
+                }
+
+                it("should parse double values") {
+                    let value: Int = parser!["root"]["attributeElement"].element!.attribute(by: "intAttr")!.value()
+                    expect(value) == 5
+                }
+
+                it("should parse double values") {
+                    let value: Double = parser!["root"]["attributeElement"].element!.attribute(by: "doubleAttr")!.value()
+                    expect(value) == 100.45
+                }
+
+                it("should parse float values") {
+                    let value: Float = parser!["root"]["attributeElement"].element!.attribute(by: "floatAttr")!.value()
+                    expect(value) == 44.12
+                }
+
+                it("should parse bool values") {
+                    let value: Bool = parser!["root"]["attributeElement"].element!.attribute(by: "boolAttr")!.value()
+                    expect(value) == false
                 }
             }
         }


### PR DESCRIPTION
Change the approach with attributes so that there is a new type describing attribute (`XMLAttribute`) versus having it simply be a string type. The string type was somewhat limiting in terms of extensibility
and future proofing.

This also deprecates the `attributes` collection in favor of using `attribute(by: name)`.

Related to #74.