### PR TITLE
Fix build error on Xcode 8.3

### DIFF
--- a/Source/SWXMLHash.swift
+++ b/Source/SWXMLHash.swift
@@ -763,7 +763,7 @@ public class XMLElement: XMLContent {
         return children
             .map({ $0 as? TextElement })
             .flatMap({ $0 })
-            .reduce("", { $0 + $1!.text })
+            .reduce("", { $0 + $1.text })
     }
 
     /// All child elements (text or XML)


### PR DESCRIPTION
This will fix an issue:
```
Source/SWXMLHash.swift:721:34: error: cannot force unwrap value of non-optional type 'TextElement'
            .reduce("", { $0 + $1!.text })
                               ~~^
```