### PR TITLE
Add `recursiveText` property for `XMLElement`.

### DIFF
--- a/Source/SWXMLHash.swift
+++ b/Source/SWXMLHash.swift
@@ -766,7 +766,7 @@ public class XMLElement: XMLContent {
             .reduce("", { $0 + $1.text })
     }
 
-    /// The inner text of the element and it's children
+    /// The inner text of the element and its children
     public var recursiveText: String {
         return children.reduce("", {
             if let textElement = $1 as? TextElement {

--- a/Source/SWXMLHash.swift
+++ b/Source/SWXMLHash.swift
@@ -766,6 +766,19 @@ public class XMLElement: XMLContent {
             .reduce("", { $0 + $1.text })
     }
 
+    /// The inner text of the element and it's children
+    public var recursiveText: String {
+        return children.reduce("", {
+            if let textElement = $1 as? TextElement {
+                return $0 + textElement.text
+            } else if let xmlElement = $1 as? XMLElement {
+                return $0 + xmlElement.recursiveText
+            } else {
+                return $0
+            }
+        })
+    }
+
     /// All child elements (text or XML)
     public var children = [XMLContent]()
     var count: Int = 0

--- a/Tests/SWXMLHashTests/XMLParsingTests.swift
+++ b/Tests/SWXMLHashTests/XMLParsingTests.swift
@@ -116,6 +116,31 @@ class XMLParsingTests: XCTestCase {
         }
     }
 
+    func testShouldBeAbleToRecursiveOutputTextContent() {
+        let mixedContentXmlInputs = [
+            // From SourceKit cursor info key.annotated_decl
+            "<Declaration>typealias SomeHandle = <Type usr=\"s:Su\">UInt</Type></Declaration>",
+            "<Declaration>var points: [<Type usr=\"c:objc(cs)Location\">Location</Type>] { get set }</Declaration>",
+            // From SourceKit cursor info key.fully_annotated_decl
+            "<decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <decl.name>SomeHandle</decl.name> = <ref.struct usr=\"s:Su\">UInt</ref.struct></decl.typealias>",
+            "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>points</decl.name>: <decl.var.type>[<ref.class usr=\"c:objc(cs)Location\">Location</ref.class>]</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>",
+            "<decl.function.method.instance><syntaxtype.keyword>fileprivate</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>documentedMemberFunc</decl.name>()</decl.function.method.instance>"
+        ]
+
+        let recursiveTextOutputs = [
+            "typealias SomeHandle = UInt",
+            "var points: [Location] { get set }",
+
+            "typealias SomeHandle = UInt",
+            "var points: [Location] { get set }",
+            "fileprivate func documentedMemberFunc()"
+        ]
+
+        for (index, mixedContentXml) in mixedContentXmlInputs.enumerated() {
+            XCTAssertEqual(SWXMLHash.parse(mixedContentXml).element!.recursiveText, recursiveTextOutputs[index])
+        }
+    }
+
     func testShouldHandleInterleavingXMLElements() {
         let interleavedXml = "<html><body><p>one</p><div>two</div><p>three</p><div>four</div></body></html>"
         let parsed = SWXMLHash.parse(interleavedXml)
@@ -187,6 +212,7 @@ extension XMLParsingTests {
             ("testShouldBeAbleToEnumerateChildren", testShouldBeAbleToEnumerateChildren),
             ("testShouldBeAbleToHandleMixedContent", testShouldBeAbleToHandleMixedContent),
             ("testShouldBeAbleToIterateOverMixedContent", testShouldBeAbleToIterateOverMixedContent),
+            ("testShouldBeAbleToRecursiveOutputTextContent", testShouldBeAbleToRecursiveOutputTextContent),
             ("testShouldHandleInterleavingXMLElements", testShouldHandleInterleavingXMLElements),
             ("testShouldBeAbleToProvideADescriptionForTheDocument", testShouldBeAbleToProvideADescriptionForTheDocument),
             ("testShouldReturnNilWhenKeysDontMatch", testShouldReturnNilWhenKeysDontMatch),


### PR DESCRIPTION
This is useful when we want to get 
```
fileprivate func documentedMemberFunc()
```
from 
```
<decl.function.method.instance><syntaxtype.keyword>fileprivate</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>documentedMemberFunc</decl.name>()</decl.function.method.instance>
```