### PR TITLE
[4.0] Lower case enums and better Swift 4 compatibility

### DIFF
--- a/Source/SWXMLHash+TypeConversion.swift
+++ b/Source/SWXMLHash+TypeConversion.swift
@@ -98,9 +98,9 @@ public extension XMLIndexer {
      */
     func value<T: XMLAttributeDeserializable>(ofAttribute attr: String) throws -> T {
         switch self {
-        case .Element(let element):
+        case .element(let element):
             return try element.value(ofAttribute: attr)
-        case .Stream(let opStream):
+        case .stream(let opStream):
             return try opStream.findElements().value(ofAttribute: attr)
         default:
             throw XMLDeserializationError.NodeIsInvalid(node: self)
@@ -116,9 +116,9 @@ public extension XMLIndexer {
      */
     func value<T: XMLAttributeDeserializable>(ofAttribute attr: String) -> T? {
         switch self {
-        case .Element(let element):
+        case .element(let element):
             return element.value(ofAttribute: attr)
-        case .Stream(let opStream):
+        case .stream(let opStream):
             return opStream.findElements().value(ofAttribute: attr)
         default:
             return nil
@@ -135,11 +135,11 @@ public extension XMLIndexer {
      */
     func value<T: XMLAttributeDeserializable>(ofAttribute attr: String) throws -> [T] {
         switch self {
-        case .List(let elements):
+        case .list(let elements):
             return try elements.map { try $0.value(ofAttribute: attr) }
-        case .Element(let element):
+        case .element(let element):
             return try [element].map { try $0.value(ofAttribute: attr) }
-        case .Stream(let opStream):
+        case .stream(let opStream):
             return try opStream.findElements().value(ofAttribute: attr)
         default:
             throw XMLDeserializationError.NodeIsInvalid(node: self)
@@ -156,11 +156,11 @@ public extension XMLIndexer {
      */
     func value<T: XMLAttributeDeserializable>(ofAttribute attr: String) throws -> [T]? {
         switch self {
-        case .List(let elements):
+        case .list(let elements):
             return try elements.map { try $0.value(ofAttribute: attr) }
-        case .Element(let element):
+        case .element(let element):
             return try [element].map { try $0.value(ofAttribute: attr) }
-        case .Stream(let opStream):
+        case .stream(let opStream):
             return try opStream.findElements().value(ofAttribute: attr)
         default:
             return nil
@@ -177,11 +177,11 @@ public extension XMLIndexer {
      */
     func value<T: XMLAttributeDeserializable>(ofAttribute attr: String) throws -> [T?] {
         switch self {
-        case .List(let elements):
+        case .list(let elements):
             return elements.map { $0.value(ofAttribute: attr) }
-        case .Element(let element):
+        case .element(let element):
             return [element].map { $0.value(ofAttribute: attr) }
-        case .Stream(let opStream):
+        case .stream(let opStream):
             return try opStream.findElements().value(ofAttribute: attr)
         default:
             throw XMLDeserializationError.NodeIsInvalid(node: self)
@@ -198,9 +198,9 @@ public extension XMLIndexer {
     */
     func value<T: XMLElementDeserializable>() throws -> T {
         switch self {
-        case .Element(let element):
+        case .element(let element):
             return try T.deserialize(element)
-        case .Stream(let opStream):
+        case .stream(let opStream):
             return try opStream.findElements().value()
         default:
             throw XMLDeserializationError.NodeIsInvalid(node: self)
@@ -215,9 +215,9 @@ public extension XMLIndexer {
     */
     func value<T: XMLElementDeserializable>() throws -> T? {
         switch self {
-        case .Element(let element):
+        case .element(let element):
             return try T.deserialize(element)
-        case .Stream(let opStream):
+        case .stream(let opStream):
             return try opStream.findElements().value()
         default:
             return nil
@@ -232,11 +232,11 @@ public extension XMLIndexer {
     */
     func value<T: XMLElementDeserializable>() throws -> [T] {
         switch self {
-        case .List(let elements):
+        case .list(let elements):
             return try elements.map { try T.deserialize($0) }
-        case .Element(let element):
+        case .element(let element):
             return try [element].map { try T.deserialize($0) }
-        case .Stream(let opStream):
+        case .stream(let opStream):
             return try opStream.findElements().value()
         default:
             return []
@@ -251,11 +251,11 @@ public extension XMLIndexer {
     */
     func value<T: XMLElementDeserializable>() throws -> [T]? {
         switch self {
-        case .List(let elements):
+        case .list(let elements):
             return try elements.map { try T.deserialize($0) }
-        case .Element(let element):
+        case .element(let element):
             return try [element].map { try T.deserialize($0) }
-        case .Stream(let opStream):
+        case .stream(let opStream):
             return try opStream.findElements().value()
         default:
             return nil
@@ -270,11 +270,11 @@ public extension XMLIndexer {
     */
     func value<T: XMLElementDeserializable>() throws -> [T?] {
         switch self {
-        case .List(let elements):
+        case .list(let elements):
             return try elements.map { try T.deserialize($0) }
-        case .Element(let element):
+        case .element(let element):
             return try [element].map { try T.deserialize($0) }
-        case .Stream(let opStream):
+        case .stream(let opStream):
             return try opStream.findElements().value()
         default:
             return []
@@ -291,9 +291,9 @@ public extension XMLIndexer {
     */
     func value<T: XMLIndexerDeserializable>() throws -> T {
         switch self {
-        case .Element:
+        case .element:
             return try T.deserialize(self)
-        case .Stream(let opStream):
+        case .stream(let opStream):
             return try opStream.findElements().value()
         default:
             throw XMLDeserializationError.NodeIsInvalid(node: self)
@@ -308,9 +308,9 @@ public extension XMLIndexer {
     */
     func value<T: XMLIndexerDeserializable>() throws -> T? {
         switch self {
-        case .Element:
+        case .element:
             return try T.deserialize(self)
-        case .Stream(let opStream):
+        case .stream(let opStream):
             return try opStream.findElements().value()
         default:
             return nil
@@ -325,11 +325,11 @@ public extension XMLIndexer {
     */
     func value<T>() throws -> [T] where T: XMLIndexerDeserializable {
         switch self {
-        case .List(let elements):
+        case .list(let elements):
             return try elements.map { try T.deserialize( XMLIndexer($0) ) }
-        case .Element(let element):
+        case .element(let element):
             return try [element].map { try T.deserialize( XMLIndexer($0) ) }
-        case .Stream(let opStream):
+        case .stream(let opStream):
             return try opStream.findElements().value()
         default:
             throw XMLDeserializationError.NodeIsInvalid(node: self)
@@ -344,11 +344,11 @@ public extension XMLIndexer {
     */
     func value<T: XMLIndexerDeserializable>() throws -> [T]? {
         switch self {
-        case .List(let elements):
+        case .list(let elements):
             return try elements.map { try T.deserialize( XMLIndexer($0) ) }
-        case .Element(let element):
+        case .element(let element):
             return try [element].map { try T.deserialize( XMLIndexer($0) ) }
-        case .Stream(let opStream):
+        case .stream(let opStream):
             return try opStream.findElements().value()
         default:
             return nil
@@ -363,11 +363,11 @@ public extension XMLIndexer {
     */
     func value<T: XMLIndexerDeserializable>() throws -> [T?] {
         switch self {
-        case .List(let elements):
+        case .list(let elements):
             return try elements.map { try T.deserialize( XMLIndexer($0) ) }
-        case .Element(let element):
+        case .element(let element):
             return try [element].map { try T.deserialize( XMLIndexer($0) ) }
-        case .Stream(let opStream):
+        case .stream(let opStream):
             return try opStream.findElements().value()
         default:
             throw XMLDeserializationError.NodeIsInvalid(node: self)

--- a/Source/SWXMLHash.swift
+++ b/Source/SWXMLHash.swift
@@ -444,12 +444,38 @@ public class IndexOps {
 
 /// Error type that is thrown when an indexing or parsing operation fails.
 public enum IndexingError: Error {
-    case Attribute(attr: String)
-    case AttributeValue(attr: String, value: String)
-    case Key(key: String)
-    case Index(idx: Int)
-    case Init(instance: AnyObject)
-    case Error
+    case attribute(attr: String)
+    case attributeValue(attr: String, value: String)
+    case key(key: String)
+    case index(idx: Int)
+    case initialize(instance: AnyObject)
+    case error
+
+    // unavailable
+    @available(*, unavailable, renamed: "attribute(attr:)")
+    public static func Attribute(attr: String) -> IndexingError {
+        fatalError("unavailable")
+    }
+    @available(*, unavailable, renamed: "attributeValue(attr:value:)")
+    public static func AttributeValue(attr: String, value: String) -> IndexingError {
+        fatalError("unavailable")
+    }
+    @available(*, unavailable, renamed: "key(key:)")
+    public static func Key(key: String) -> IndexingError {
+        fatalError("unavailable")
+    }
+    @available(*, unavailable, renamed: "index(idx:)")
+    public static func Index(idx: Int) -> IndexingError {
+        fatalError("unavailable")
+    }
+    @available(*, unavailable, renamed: "initialize(instance:)")
+    public static func Init(instance: AnyObject) -> IndexingError {
+        fatalError("unavailable")
+    }
+    @available(*, unavailable, renamed: "error")
+    public static var Error: IndexingError {
+        fatalError("unavailable")
+    }
 }
 
 /// Returned from SWXMLHash, allows easy element lookup into XML data.
@@ -520,14 +546,14 @@ public enum XMLIndexer: Sequence {
             if let elem = list.filter({$0.attribute(by: attr)?.text == value}).first {
                 return .Element(elem)
             }
-            throw IndexingError.AttributeValue(attr: attr, value: value)
+            throw IndexingError.attributeValue(attr: attr, value: value)
         case .Element(let elem):
             if elem.attribute(by: attr)?.text == value {
                 return .Element(elem)
             }
-            throw IndexingError.AttributeValue(attr: attr, value: value)
+            throw IndexingError.attributeValue(attr: attr, value: value)
         default:
-            throw IndexingError.Attribute(attr: attr)
+            throw IndexingError.attribute(attr: attr)
         }
     }
 
@@ -544,7 +570,7 @@ public enum XMLIndexer: Sequence {
         case let value as LazyXMLParser:
             self = .Stream(IndexOps(parser: value))
         default:
-            throw IndexingError.Init(instance: rawObject)
+            throw IndexingError.initialize(instance: rawObject)
         }
     }
 
@@ -585,7 +611,7 @@ public enum XMLIndexer: Sequence {
             }
             fallthrough
         default:
-            throw IndexingError.Key(key: key)
+            throw IndexingError.key(key: key)
         }
     }
 
@@ -601,7 +627,7 @@ public enum XMLIndexer: Sequence {
         } catch let error as IndexingError {
             return .XMLError(error)
         } catch {
-            return .XMLError(IndexingError.Key(key: key))
+            return .XMLError(IndexingError.key(key: key))
         }
     }
 
@@ -621,14 +647,14 @@ public enum XMLIndexer: Sequence {
             if index <= list.count {
                 return .Element(list[index])
             }
-            return .XMLError(IndexingError.Index(idx: index))
+            return .XMLError(IndexingError.index(idx: index))
         case .Element(let elem):
             if index == 0 {
                 return .Element(elem)
             }
             fallthrough
         default:
-            return .XMLError(IndexingError.Index(idx: index))
+            return .XMLError(IndexingError.index(idx: index))
         }
     }
 
@@ -644,7 +670,7 @@ public enum XMLIndexer: Sequence {
         } catch let error as IndexingError {
             return .XMLError(error)
         } catch {
-            return .XMLError(IndexingError.Index(idx: index))
+            return .XMLError(IndexingError.index(idx: index))
         }
     }
 
@@ -697,17 +723,17 @@ extension IndexingError: CustomStringConvertible {
     /// The description for the `IndexingError`.
     public var description: String {
         switch self {
-        case .Attribute(let attr):
+        case .attribute(let attr):
             return "XML Attribute Error: Missing attribute [\"\(attr)\"]"
-        case .AttributeValue(let attr, let value):
+        case .attributeValue(let attr, let value):
             return "XML Attribute Error: Missing attribute [\"\(attr)\"] with value [\"\(value)\"]"
-        case .Key(let key):
+        case .key(let key):
             return "XML Element Error: Incorrect key [\"\(key)\"]"
-        case .Index(let index):
+        case .index(let index):
             return "XML Element Error: Incorrect index [\"\(index)\"]"
-        case .Init(let instance):
+        case .initialize(let instance):
             return "XML Indexer Error: initialization with Object [\"\(instance)\"]"
-        case .Error:
+        case .error:
             return "Unknown Error"
         }
     }

--- a/Source/SWXMLHash.swift
+++ b/Source/SWXMLHash.swift
@@ -486,10 +486,12 @@ public enum XMLIndexer: Sequence {
     case xmlError(IndexingError)
 
     // unavailable
+#if !swift(>=3.2) // `Sequence.Element` is added on Swift 4.0 including with `-swift-version 3`
     @available(*, unavailable, renamed: "element(_:)")
     public static func Element(_: XMLElement) -> XMLIndexer {
         fatalError("unavailable")
     }
+#endif
     @available(*, unavailable, renamed: "list(_:)")
     public static func List(_: [XMLElement]) -> XMLIndexer {
         fatalError("unavailable")

--- a/Tests/SWXMLHashTests/XMLParsingTests.swift
+++ b/Tests/SWXMLHashTests/XMLParsingTests.swift
@@ -188,7 +188,7 @@ class XMLParsingTests: XCTestCase {
     func testShouldStillReturnErrorsWhenAccessingViaSubscripting() {
         var err: IndexingError? = nil
         switch xml!["what"]["subelement"][5]["nomatch"] {
-        case .XMLError(let error):
+        case .xmlError(let error):
             err = error
         default:
             err = nil


### PR DESCRIPTION
- Change cases of `IndexingError` to lowercase
  - `Init(instance: AnyObject)` is renamed to `initialize(instance: AnyObject)` since `init` is recognized as initializer.
- Change cases of `XMLIndexer` to lowercase
- `@available` of `XMLIndexer.Element` is guarded by `#if !swift(>=3.2)` for avoiding [SR-4951](https://bugs.swift.org/browse/SR-4951).
  Current Swift 4 compiler with `-swift-version 3` seems Swift 3.2. It may be necessary to change this when Xcode 9 beta starts in the future.