### PR TITLE
Convert all public enum members to lowercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Given:
 Will return "Foo".
 
 ```swift
-xml["root"]["header"]["title"].element?.text
+xml["root"]["header"]["title"].xmlElement?.text
 ```
 
 ### Multiple Elements Lookup
@@ -164,7 +164,7 @@ Given:
 The below will return "John".
 
 ```swift
-xml["root"]["catalog"]["book"][1]["author"].element?.text
+xml["root"]["catalog"]["book"][1]["author"].xmlElement?.text
 ```
 
 ### Attributes Usage
@@ -186,13 +186,13 @@ Given:
 The below will return "123".
 
 ```swift
-xml["root"]["catalog"]["book"][1].element?.attribute(by: "id")?.text
+xml["root"]["catalog"]["book"][1].xmlElement?.attribute(by: "id")?.text
 ```
 
 Alternatively, you can look up an element with specific attributes. The below will return "John".
 
 ```swift
-xml["root"]["catalog"]["book"].withAttr("id", "123")["author"].element?.text
+xml["root"]["catalog"]["book"].withAttr("id", "123")["author"].xmlElement?.text
 ```
 
 ### Returning All Elements At Current Level
@@ -215,7 +215,7 @@ The `all` method will iterate over all nodes at the indexed level. The code belo
 
 ```swift
 ", ".join(xml["root"]["catalog"]["book"].all.map { elem in
-  elem["genre"].element!.text!
+  elem["genre"].xmlElement!.text!
 })
 ```
 
@@ -223,7 +223,7 @@ You can also iterate over the `all` method:
 
 ```swift
 for elem in xml["root"]["catalog"]["book"].all {
-  print(elem["genre"].element!.text!)
+  print(elem["genre"].xmlElement!.text!)
 }
 ```
 
@@ -231,7 +231,7 @@ Alternatively, XMLIndexer provides `for-in` support directly from the index (no 
 
 ```swift
 for elem in xml["root"]["catalog"]["book"] {
-  print(elem["genre"].element!.text!)
+  print(elem["genre"].xmlElement!.text!)
 }
 ```
 
@@ -256,7 +256,7 @@ The below will `print` "root", "catalog", "book", "genre", "title", and "date" (
 ```swift
 func enumerate(indexer: XMLIndexer) {
   for child in indexer.children {
-    print(child.element!.name)
+    print(child.xmlElement!.name)
     enumerate(child)
   }
 }
@@ -280,9 +280,9 @@ __Or__ using the existing indexing functionality:
 
 ```swift
 switch xml["root"]["what"]["header"]["foo"] {
-case .Element(let elem):
+case .xmlElement(let elem):
   // everything is good, code away!
-case .XMLError(let error):
+case .xmlError(let error):
   // error is an IndexingError instance that you can deal with
 }
 ```
@@ -404,7 +404,7 @@ See below for the code snippet to get this to work and note in particular the `p
 extension NSDate: XMLElementDeserializable {
   public static func deserialize(_ element: XMLElement) throws -> Self {
     guard let dateAsString = element.text else {
-      throw XMLDeserializationError.NodeHasNoValue
+      throw XMLDeserializationError.nodeHasNoValue
     }
 
     let dateFormatter = NSDateFormatter()
@@ -412,7 +412,7 @@ extension NSDate: XMLElementDeserializable {
     let date = dateFormatter.dateFromString(dateAsString)
 
     guard let validDate = date else {
-      throw XMLDeserializationError.TypeConversionFailed(type: "Date", element: element)
+      throw XMLDeserializationError.typeConversionFailed(type: "Date", element: element)
     }
 
     // NOTE THIS

--- a/SWXMLHashPlayground.playground/section-1.swift
+++ b/SWXMLHashPlayground.playground/section-1.swift
@@ -26,12 +26,12 @@ var xml = SWXMLHash.parse(xmlWithNamespace)
 let count = xml["root"].all.count
 
 // "Apples"
-xml["root"]["h:table"]["h:tr"]["h:td"][0].element!.text!
+xml["root"]["h:table"]["h:tr"]["h:td"][0].xmlElement!.text!
 
 // enumerate all child elements (procedurally)
 func enumerate(indexer: XMLIndexer, level: Int) {
     for child in indexer.children {
-        let name = child.element!.name
+        let name = child.xmlElement!.name
         print("\(level) \(name)")
 
         enumerate(indexer: child, level: level + 1)
@@ -42,7 +42,7 @@ enumerate(indexer: xml, level: 0)
 
 // enumerate all child elements (functionally)
 func reduceName(names: String, elem: XMLIndexer) -> String {
-    return names + elem.element!.name + elem.children.reduce(", ", reduceName)
+    return names + elem.xmlElement!.name + elem.children.reduce(", ", reduceName)
 }
 
 xml.children.reduce("elements: ", reduceName)

--- a/Source/SWXMLHash+TypeConversion.swift
+++ b/Source/SWXMLHash+TypeConversion.swift
@@ -26,11 +26,11 @@ public extension XMLIndexerDeserializable {
 
     - parameters:
         - element: the XMLIndexer to be deserialized
-    - throws: an XMLDeserializationError.ImplementationIsMissing if no implementation is found
+    - throws: an XMLDeserializationError.implementationIsMissing if no implementation is found
     - returns: this won't ever return because of the error being thrown
     */
     static func deserialize(_ element: XMLIndexer) throws -> Self {
-        throw XMLDeserializationError.ImplementationIsMissing(
+        throw XMLDeserializationError.implementationIsMissing(
             method: "XMLIndexerDeserializable.deserialize(element: XMLIndexer)")
     }
 }
@@ -50,11 +50,11 @@ public extension XMLElementDeserializable {
 
     - parameters:
         - element: the XMLElement to be deserialized
-    - throws: an XMLDeserializationError.ImplementationIsMissing if no implementation is found
+    - throws: an XMLDeserializationError.implementationIsMissing if no implementation is found
     - returns: this won't ever return because of the error being thrown
     */
     static func deserialize(_ element: XMLElement) throws -> Self {
-        throw XMLDeserializationError.ImplementationIsMissing(
+        throw XMLDeserializationError.implementationIsMissing(
             method: "XMLElementDeserializable.deserialize(element: XMLElement)")
     }
 }
@@ -73,11 +73,11 @@ public extension XMLAttributeDeserializable {
 
      - parameters:
          - attribute: The XMLAttribute to be deserialized
-     - throws: an XMLDeserializationError.ImplementationIsMissing if no implementation is found
+     - throws: an XMLDeserializationError.implementationIsMissing if no implementation is found
      - returns: this won't ever return because of the error being thrown
      */
     static func deserialize(attribute: XMLAttribute) throws -> Self {
-        throw XMLDeserializationError.ImplementationIsMissing(
+        throw XMLDeserializationError.implementationIsMissing(
             method: "XMLAttributeDeserializable(element: XMLAttribute)")
     }
 }
@@ -98,12 +98,12 @@ public extension XMLIndexer {
      */
     func value<T: XMLAttributeDeserializable>(ofAttribute attr: String) throws -> T {
         switch self {
-        case .Element(let element):
+        case .xmlElement(let element):
             return try element.value(ofAttribute: attr)
-        case .Stream(let opStream):
+        case .stream(let opStream):
             return try opStream.findElements().value(ofAttribute: attr)
         default:
-            throw XMLDeserializationError.NodeIsInvalid(node: self)
+            throw XMLDeserializationError.nodeIsInvalid(node: self)
         }
     }
 
@@ -116,9 +116,9 @@ public extension XMLIndexer {
      */
     func value<T: XMLAttributeDeserializable>(ofAttribute attr: String) -> T? {
         switch self {
-        case .Element(let element):
+        case .xmlElement(let element):
             return element.value(ofAttribute: attr)
-        case .Stream(let opStream):
+        case .stream(let opStream):
             return opStream.findElements().value(ofAttribute: attr)
         default:
             return nil
@@ -135,14 +135,14 @@ public extension XMLIndexer {
      */
     func value<T: XMLAttributeDeserializable>(ofAttribute attr: String) throws -> [T] {
         switch self {
-        case .List(let elements):
+        case .list(let elements):
             return try elements.map { try $0.value(ofAttribute: attr) }
-        case .Element(let element):
+        case .xmlElement(let element):
             return try [element].map { try $0.value(ofAttribute: attr) }
-        case .Stream(let opStream):
+        case .stream(let opStream):
             return try opStream.findElements().value(ofAttribute: attr)
         default:
-            throw XMLDeserializationError.NodeIsInvalid(node: self)
+            throw XMLDeserializationError.nodeIsInvalid(node: self)
         }
     }
 
@@ -156,11 +156,11 @@ public extension XMLIndexer {
      */
     func value<T: XMLAttributeDeserializable>(ofAttribute attr: String) throws -> [T]? {
         switch self {
-        case .List(let elements):
+        case .list(let elements):
             return try elements.map { try $0.value(ofAttribute: attr) }
-        case .Element(let element):
+        case .xmlElement(let element):
             return try [element].map { try $0.value(ofAttribute: attr) }
-        case .Stream(let opStream):
+        case .stream(let opStream):
             return try opStream.findElements().value(ofAttribute: attr)
         default:
             return nil
@@ -177,14 +177,14 @@ public extension XMLIndexer {
      */
     func value<T: XMLAttributeDeserializable>(ofAttribute attr: String) throws -> [T?] {
         switch self {
-        case .List(let elements):
+        case .list(let elements):
             return elements.map { $0.value(ofAttribute: attr) }
-        case .Element(let element):
+        case .xmlElement(let element):
             return [element].map { $0.value(ofAttribute: attr) }
-        case .Stream(let opStream):
+        case .stream(let opStream):
             return try opStream.findElements().value(ofAttribute: attr)
         default:
-            throw XMLDeserializationError.NodeIsInvalid(node: self)
+            throw XMLDeserializationError.nodeIsInvalid(node: self)
         }
     }
 
@@ -193,17 +193,17 @@ public extension XMLIndexer {
     /**
     Attempts to deserialize the current XMLElement element to `T`
 
-    - throws: an XMLDeserializationError.NodeIsInvalid if the current indexed level isn't an Element
+    - throws: an XMLDeserializationError.nodeIsInvalid if the current indexed level isn't an Element
     - returns: the deserialized `T` value
     */
     func value<T: XMLElementDeserializable>() throws -> T {
         switch self {
-        case .Element(let element):
+        case .xmlElement(let element):
             return try T.deserialize(element)
-        case .Stream(let opStream):
+        case .stream(let opStream):
             return try opStream.findElements().value()
         default:
-            throw XMLDeserializationError.NodeIsInvalid(node: self)
+            throw XMLDeserializationError.nodeIsInvalid(node: self)
         }
     }
 
@@ -215,9 +215,9 @@ public extension XMLIndexer {
     */
     func value<T: XMLElementDeserializable>() throws -> T? {
         switch self {
-        case .Element(let element):
+        case .xmlElement(let element):
             return try T.deserialize(element)
-        case .Stream(let opStream):
+        case .stream(let opStream):
             return try opStream.findElements().value()
         default:
             return nil
@@ -232,11 +232,11 @@ public extension XMLIndexer {
     */
     func value<T: XMLElementDeserializable>() throws -> [T] {
         switch self {
-        case .List(let elements):
+        case .list(let elements):
             return try elements.map { try T.deserialize($0) }
-        case .Element(let element):
+        case .xmlElement(let element):
             return try [element].map { try T.deserialize($0) }
-        case .Stream(let opStream):
+        case .stream(let opStream):
             return try opStream.findElements().value()
         default:
             return []
@@ -251,11 +251,11 @@ public extension XMLIndexer {
     */
     func value<T: XMLElementDeserializable>() throws -> [T]? {
         switch self {
-        case .List(let elements):
+        case .list(let elements):
             return try elements.map { try T.deserialize($0) }
-        case .Element(let element):
+        case .xmlElement(let element):
             return try [element].map { try T.deserialize($0) }
-        case .Stream(let opStream):
+        case .stream(let opStream):
             return try opStream.findElements().value()
         default:
             return nil
@@ -270,11 +270,11 @@ public extension XMLIndexer {
     */
     func value<T: XMLElementDeserializable>() throws -> [T?] {
         switch self {
-        case .List(let elements):
+        case .list(let elements):
             return try elements.map { try T.deserialize($0) }
-        case .Element(let element):
+        case .xmlElement(let element):
             return try [element].map { try T.deserialize($0) }
-        case .Stream(let opStream):
+        case .stream(let opStream):
             return try opStream.findElements().value()
         default:
             return []
@@ -291,12 +291,12 @@ public extension XMLIndexer {
     */
     func value<T: XMLIndexerDeserializable>() throws -> T {
         switch self {
-        case .Element:
+        case .xmlElement:
             return try T.deserialize(self)
-        case .Stream(let opStream):
+        case .stream(let opStream):
             return try opStream.findElements().value()
         default:
-            throw XMLDeserializationError.NodeIsInvalid(node: self)
+            throw XMLDeserializationError.nodeIsInvalid(node: self)
         }
     }
 
@@ -308,9 +308,9 @@ public extension XMLIndexer {
     */
     func value<T: XMLIndexerDeserializable>() throws -> T? {
         switch self {
-        case .Element:
+        case .xmlElement:
             return try T.deserialize(self)
-        case .Stream(let opStream):
+        case .stream(let opStream):
             return try opStream.findElements().value()
         default:
             return nil
@@ -325,14 +325,14 @@ public extension XMLIndexer {
     */
     func value<T>() throws -> [T] where T: XMLIndexerDeserializable {
         switch self {
-        case .List(let elements):
+        case .list(let elements):
             return try elements.map { try T.deserialize( XMLIndexer($0) ) }
-        case .Element(let element):
+        case .xmlElement(let element):
             return try [element].map { try T.deserialize( XMLIndexer($0) ) }
-        case .Stream(let opStream):
+        case .stream(let opStream):
             return try opStream.findElements().value()
         default:
-            throw XMLDeserializationError.NodeIsInvalid(node: self)
+            throw XMLDeserializationError.nodeIsInvalid(node: self)
         }
     }
 
@@ -344,11 +344,11 @@ public extension XMLIndexer {
     */
     func value<T: XMLIndexerDeserializable>() throws -> [T]? {
         switch self {
-        case .List(let elements):
+        case .list(let elements):
             return try elements.map { try T.deserialize( XMLIndexer($0) ) }
-        case .Element(let element):
+        case .xmlElement(let element):
             return try [element].map { try T.deserialize( XMLIndexer($0) ) }
-        case .Stream(let opStream):
+        case .stream(let opStream):
             return try opStream.findElements().value()
         default:
             return nil
@@ -363,14 +363,14 @@ public extension XMLIndexer {
     */
     func value<T: XMLIndexerDeserializable>() throws -> [T?] {
         switch self {
-        case .List(let elements):
+        case .list(let elements):
             return try elements.map { try T.deserialize( XMLIndexer($0) ) }
-        case .Element(let element):
+        case .xmlElement(let element):
             return try [element].map { try T.deserialize( XMLIndexer($0) ) }
-        case .Stream(let opStream):
+        case .stream(let opStream):
             return try opStream.findElements().value()
         default:
-            throw XMLDeserializationError.NodeIsInvalid(node: self)
+            throw XMLDeserializationError.nodeIsInvalid(node: self)
         }
     }
 }
@@ -390,7 +390,7 @@ extension XMLElement {
         if let attr = self.attribute(by: attr) {
             return try T.deserialize(attr)
         } else {
-            throw XMLDeserializationError.AttributeDoesNotExist(element: self, attribute: attr)
+            throw XMLDeserializationError.attributeDoesNotExist(element: self, attribute: attr)
         }
     }
 
@@ -411,7 +411,7 @@ extension XMLElement {
     /**
      Gets the text associated with this element, or throws an exception if the text is empty
 
-     - throws: XMLDeserializationError.NodeHasNoValue if the element text is empty
+     - throws: XMLDeserializationError.nodeHasNoValue if the element text is empty
      - returns: The element text
      */
     internal func nonEmptyTextOrThrow() throws -> String {
@@ -419,7 +419,7 @@ extension XMLElement {
             return textVal
         }
 
-        throw XMLDeserializationError.NodeHasNoValue
+        throw XMLDeserializationError.nodeHasNoValue
     }
 }
 
@@ -427,27 +427,27 @@ extension XMLElement {
 
 /// The error that is thrown if there is a problem with deserialization
 public enum XMLDeserializationError: Error, CustomStringConvertible {
-    case ImplementationIsMissing(method: String)
-    case NodeIsInvalid(node: XMLIndexer)
-    case NodeHasNoValue
-    case TypeConversionFailed(type: String, element: XMLElement)
-    case AttributeDoesNotExist(element: XMLElement, attribute: String)
-    case AttributeDeserializationFailed(type: String, attribute: XMLAttribute)
+    case implementationIsMissing(method: String)
+    case nodeIsInvalid(node: XMLIndexer)
+    case nodeHasNoValue
+    case typeConversionFailed(type: String, element: XMLElement)
+    case attributeDoesNotExist(element: XMLElement, attribute: String)
+    case attributeDeserializationFailed(type: String, attribute: XMLAttribute)
 
     /// The text description for the error thrown
     public var description: String {
         switch self {
-        case .ImplementationIsMissing(let method):
+        case .implementationIsMissing(let method):
             return "This deserialization method is not implemented: \(method)"
-        case .NodeIsInvalid(let node):
+        case .nodeIsInvalid(let node):
             return "This node is invalid: \(node)"
-        case .NodeHasNoValue:
+        case .nodeHasNoValue:
             return "This node is empty"
-        case .TypeConversionFailed(let type, let node):
+        case .typeConversionFailed(let type, let node):
             return "Can't convert node \(node) to value of type \(type)"
-        case .AttributeDoesNotExist(let element, let attribute):
+        case .attributeDoesNotExist(let element, let attribute):
             return "Element \(element) does not contain attribute: \(attribute)"
-        case .AttributeDeserializationFailed(let type, let attribute):
+        case .attributeDeserializationFailed(let type, let attribute):
             return "Can't convert attribute \(attribute) to value of type \(type)"
         }
     }
@@ -461,12 +461,12 @@ extension String: XMLElementDeserializable, XMLAttributeDeserializable {
 
     - parameters:
         - element: the XMLElement to be deserialized
-    - throws: an XMLDeserializationError.TypeConversionFailed if the element cannot be deserialized
+    - throws: an XMLDeserializationError.typeConversionFailed if the element cannot be deserialized
     - returns: the deserialized String value
     */
     public static func deserialize(_ element: XMLElement) throws -> String {
         guard let text = element.text else {
-            throw XMLDeserializationError.TypeConversionFailed(type: "String", element: element)
+            throw XMLDeserializationError.typeConversionFailed(type: "String", element: element)
         }
         return text
     }
@@ -488,12 +488,12 @@ extension Int: XMLElementDeserializable, XMLAttributeDeserializable {
 
     - parameters:
         - element: the XMLElement to be deserialized
-    - throws: an XMLDeserializationError.TypeConversionFailed if the element cannot be deserialized
+    - throws: an XMLDeserializationError.typeConversionFailed if the element cannot be deserialized
     - returns: the deserialized Int value
     */
     public static func deserialize(_ element: XMLElement) throws -> Int {
         guard let value = Int(try element.nonEmptyTextOrThrow()) else {
-            throw XMLDeserializationError.TypeConversionFailed(type: "Int", element: element)
+            throw XMLDeserializationError.typeConversionFailed(type: "Int", element: element)
         }
         return value
     }
@@ -502,13 +502,13 @@ extension Int: XMLElementDeserializable, XMLAttributeDeserializable {
      Attempts to deserialize XML attribute content to an Int
 
      - parameter attribute: The XMLAttribute to be deserialized
-     - throws: an XMLDeserializationError.AttributeDeserializationFailed if the attribute cannot be
+     - throws: an XMLDeserializationError.attributeDeserializationFailed if the attribute cannot be
                deserialized
      - returns: the deserialized Int value
      */
     public static func deserialize(_ attribute: XMLAttribute) throws -> Int {
         guard let value = Int(attribute.text) else {
-            throw XMLDeserializationError.AttributeDeserializationFailed(
+            throw XMLDeserializationError.attributeDeserializationFailed(
                 type: "Int", attribute: attribute)
         }
         return value
@@ -521,12 +521,12 @@ extension Double: XMLElementDeserializable, XMLAttributeDeserializable {
 
     - parameters:
         - element: the XMLElement to be deserialized
-    - throws: an XMLDeserializationError.TypeConversionFailed if the element cannot be deserialized
+    - throws: an XMLDeserializationError.typeConversionFailed if the element cannot be deserialized
     - returns: the deserialized Double value
     */
     public static func deserialize(_ element: XMLElement) throws -> Double {
         guard let value = Double(try element.nonEmptyTextOrThrow()) else {
-            throw XMLDeserializationError.TypeConversionFailed(type: "Double", element: element)
+            throw XMLDeserializationError.typeConversionFailed(type: "Double", element: element)
         }
         return value
     }
@@ -535,13 +535,13 @@ extension Double: XMLElementDeserializable, XMLAttributeDeserializable {
      Attempts to deserialize XML attribute content to a Double
 
      - parameter attribute: The XMLAttribute to be deserialized
-     - throws: an XMLDeserializationError.AttributeDeserializationFailed if the attribute cannot be
+     - throws: an XMLDeserializationError.attributeDeserializationFailed if the attribute cannot be
                deserialized
      - returns: the deserialized Double value
      */
     public static func deserialize(_ attribute: XMLAttribute) throws -> Double {
         guard let value = Double(attribute.text) else {
-            throw XMLDeserializationError.AttributeDeserializationFailed(
+            throw XMLDeserializationError.attributeDeserializationFailed(
                 type: "Double", attribute: attribute)
         }
         return value
@@ -554,12 +554,12 @@ extension Float: XMLElementDeserializable, XMLAttributeDeserializable {
 
     - parameters:
         - element: the XMLElement to be deserialized
-    - throws: an XMLDeserializationError.TypeConversionFailed if the element cannot be deserialized
+    - throws: an XMLDeserializationError.typeConversionFailed if the element cannot be deserialized
     - returns: the deserialized Float value
     */
     public static func deserialize(_ element: XMLElement) throws -> Float {
         guard let value = Float(try element.nonEmptyTextOrThrow()) else {
-            throw XMLDeserializationError.TypeConversionFailed(type: "Float", element: element)
+            throw XMLDeserializationError.typeConversionFailed(type: "Float", element: element)
         }
         return value
     }
@@ -568,13 +568,13 @@ extension Float: XMLElementDeserializable, XMLAttributeDeserializable {
      Attempts to deserialize XML attribute content to a Float
 
      - parameter attribute: The XMLAttribute to be deserialized
-     - throws: an XMLDeserializationError.AttributeDeserializationFailed if the attribute cannot be
+     - throws: an XMLDeserializationError.attributeDeserializationFailed if the attribute cannot be
                deserialized
      - returns: the deserialized Float value
      */
     public static func deserialize(_ attribute: XMLAttribute) throws -> Float {
         guard let value = Float(attribute.text) else {
-            throw XMLDeserializationError.AttributeDeserializationFailed(
+            throw XMLDeserializationError.attributeDeserializationFailed(
                 type: "Float", attribute: attribute)
         }
         return value
@@ -589,7 +589,7 @@ extension Bool: XMLElementDeserializable, XMLAttributeDeserializable {
 
      - parameters:
         - element: the XMLElement to be deserialized
-     - throws: an XMLDeserializationError.TypeConversionFailed if the element cannot be deserialized
+     - throws: an XMLDeserializationError.typeConversionFailed if the element cannot be deserialized
      - returns: the deserialized Bool value
      */
     public static func deserialize(_ element: XMLElement) throws -> Bool {
@@ -602,7 +602,7 @@ extension Bool: XMLElementDeserializable, XMLAttributeDeserializable {
      described [here](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSString_Class/#//apple_ref/occ/instp/NSString/boolValue)
 
      - parameter attribute: The XMLAttribute to be deserialized
-     - throws: an XMLDeserializationError.AttributeDeserializationFailed if the attribute cannot be
+     - throws: an XMLDeserializationError.attributeDeserializationFailed if the attribute cannot be
                deserialized
      - returns: the deserialized Bool value
      */

--- a/Source/SWXMLHash.swift
+++ b/Source/SWXMLHash.swift
@@ -444,29 +444,29 @@ public class IndexOps {
 
 /// Error type that is thrown when an indexing or parsing operation fails.
 public enum IndexingError: Error {
-    case Attribute(attr: String)
-    case AttributeValue(attr: String, value: String)
-    case Key(key: String)
-    case Index(idx: Int)
-    case Init(instance: AnyObject)
-    case Error
+    case attribute(attr: String)
+    case attributeValue(attr: String, value: String)
+    case key(key: String)
+    case index(idx: Int)
+    case `init`(instance: AnyObject)
+    case error
 }
 
 /// Returned from SWXMLHash, allows easy element lookup into XML data.
 public enum XMLIndexer: Sequence {
-    case Element(XMLElement)
-    case List([XMLElement])
-    case Stream(IndexOps)
-    case XMLError(IndexingError)
+    case xmlElement(XMLElement)
+    case list([XMLElement])
+    case stream(IndexOps)
+    case xmlError(IndexingError)
 
     /// The underlying XMLElement at the currently indexed level of XML.
-    public var element: XMLElement? {
+    public var xmlElement: XMLElement? {
         switch self {
-        case .Element(let elem):
+        case .xmlElement(let elem):
             return elem
-        case .Stream(let ops):
+        case .stream(let ops):
             let list = ops.findElements()
-            return list.element
+            return list.xmlElement
         default:
             return nil
         }
@@ -475,15 +475,15 @@ public enum XMLIndexer: Sequence {
     /// All elements at the currently indexed level
     public var all: [XMLIndexer] {
         switch self {
-        case .List(let list):
+        case .list(let list):
             var xmlList = [XMLIndexer]()
             for elem in list {
                 xmlList.append(XMLIndexer(elem))
             }
             return xmlList
-        case .Element(let elem):
+        case .xmlElement(let elem):
             return [XMLIndexer(elem)]
-        case .Stream(let ops):
+        case .stream(let ops):
             let list = ops.findElements()
             return list.all
         default:
@@ -494,7 +494,7 @@ public enum XMLIndexer: Sequence {
     /// All child elements from the currently indexed level
     public var children: [XMLIndexer] {
         var list = [XMLIndexer]()
-        for elem in all.map({ $0.element! }).flatMap({ $0 }) {
+        for elem in all.map({ $0.xmlElement! }).flatMap({ $0 }) {
             for elem in elem.xmlChildren {
                 list.append(XMLIndexer(elem))
             }
@@ -508,26 +508,26 @@ public enum XMLIndexer: Sequence {
     - parameters:
         - attr: should the name of the attribute to match on
         - value: should be the value of the attribute to match on
-    - throws: an XMLIndexer.XMLError if an element with the specified attribute isn't found
+    - throws: an XMLIndexer.xmlError if an element with the specified attribute isn't found
     - returns: instance of XMLIndexer
     */
     public func withAttr(_ attr: String, _ value: String) throws -> XMLIndexer {
         switch self {
-        case .Stream(let opStream):
+        case .stream(let opStream):
             let match = opStream.findElements()
             return try match.withAttr(attr, value)
-        case .List(let list):
+        case .list(let list):
             if let elem = list.filter({$0.attribute(by: attr)?.text == value}).first {
-                return .Element(elem)
+                return .xmlElement(elem)
             }
-            throw IndexingError.AttributeValue(attr: attr, value: value)
-        case .Element(let elem):
+            throw IndexingError.attributeValue(attr: attr, value: value)
+        case .xmlElement(let elem):
             if elem.attribute(by: attr)?.text == value {
-                return .Element(elem)
+                return .xmlElement(elem)
             }
-            throw IndexingError.AttributeValue(attr: attr, value: value)
+            throw IndexingError.attributeValue(attr: attr, value: value)
         default:
-            throw IndexingError.Attribute(attr: attr)
+            throw IndexingError.attribute(attr: attr)
         }
     }
 
@@ -540,11 +540,11 @@ public enum XMLIndexer: Sequence {
     public init(_ rawObject: AnyObject) throws {
         switch rawObject {
         case let value as XMLElement:
-            self = .Element(value)
+            self = .xmlElement(value)
         case let value as LazyXMLParser:
-            self = .Stream(IndexOps(parser: value))
+            self = .stream(IndexOps(parser: value))
         default:
-            throw IndexingError.Init(instance: rawObject)
+            throw IndexingError.init(instance: rawObject)
         }
     }
 
@@ -554,11 +554,11 @@ public enum XMLIndexer: Sequence {
     - parameter _: an instance of XMLElement
     */
     public init(_ elem: XMLElement) {
-        self = .Element(elem)
+        self = .xmlElement(elem)
     }
 
     init(_ stream: LazyXMLParser) {
-        self = .Stream(IndexOps(parser: stream))
+        self = .stream(IndexOps(parser: stream))
     }
 
     /**
@@ -566,26 +566,26 @@ public enum XMLIndexer: Sequence {
 
     - parameter key: The element name to index by
     - returns: instance of XMLIndexer to match the element (or elements) found by key
-    - throws: Throws an XMLIndexingError.Key if no element was found
+    - throws: Throws an XMLIndexingError.key if no element was found
     */
     public func byKey(_ key: String) throws -> XMLIndexer {
         switch self {
-        case .Stream(let opStream):
+        case .stream(let opStream):
             let op = IndexOp(key)
             opStream.ops.append(op)
-            return .Stream(opStream)
-        case .Element(let elem):
+            return .stream(opStream)
+        case .xmlElement(let elem):
             let match = elem.xmlChildren.filter({ $0.name == key })
             if !match.isEmpty {
                 if match.count == 1 {
-                    return .Element(match[0])
+                    return .xmlElement(match[0])
                 } else {
-                    return .List(match)
+                    return .list(match)
                 }
             }
             fallthrough
         default:
-            throw IndexingError.Key(key: key)
+            throw IndexingError.key(key: key)
         }
     }
 
@@ -599,9 +599,9 @@ public enum XMLIndexer: Sequence {
         do {
             return try self.byKey(key)
         } catch let error as IndexingError {
-            return .XMLError(error)
+            return .xmlError(error)
         } catch {
-            return .XMLError(IndexingError.Key(key: key))
+            return .xmlError(IndexingError.key(key: key))
         }
     }
 
@@ -609,26 +609,26 @@ public enum XMLIndexer: Sequence {
     Find an XML element by index within a list of XML Elements at the current level
 
     - parameter index: The 0-based index to index by
-    - throws: XMLIndexer.XMLError if the index isn't found
+    - throws: XMLIndexer.xmlError if the index isn't found
     - returns: instance of XMLIndexer to match the element (or elements) found by index
     */
     public func byIndex(_ index: Int) throws -> XMLIndexer {
         switch self {
-        case .Stream(let opStream):
+        case .stream(let opStream):
             opStream.ops[opStream.ops.count - 1].index = index
-            return .Stream(opStream)
-        case .List(let list):
+            return .stream(opStream)
+        case .list(let list):
             if index <= list.count {
-                return .Element(list[index])
+                return .xmlElement(list[index])
             }
-            return .XMLError(IndexingError.Index(idx: index))
-        case .Element(let elem):
+            return .xmlError(IndexingError.index(idx: index))
+        case .xmlElement(let elem):
             if index == 0 {
-                return .Element(elem)
+                return .xmlElement(elem)
             }
             fallthrough
         default:
-            return .XMLError(IndexingError.Index(idx: index))
+            return .xmlError(IndexingError.index(idx: index))
         }
     }
 
@@ -642,9 +642,9 @@ public enum XMLIndexer: Sequence {
         do {
             return try byIndex(index)
         } catch let error as IndexingError {
-            return .XMLError(error)
+            return .xmlError(error)
         } catch {
-            return .XMLError(IndexingError.Index(idx: index))
+            return .xmlError(IndexingError.index(idx: index))
         }
     }
 
@@ -666,7 +666,7 @@ extension XMLIndexer: Boolean {
     /// True if a valid XMLIndexer, false if an error type
     public var boolValue: Bool {
         switch self {
-        case .XMLError:
+        case .xmlError:
             return false
         default:
             return true
@@ -679,9 +679,9 @@ extension XMLIndexer: CustomStringConvertible {
     /// The XML representation of the XMLIndexer at the current level
     public var description: String {
         switch self {
-        case .List(let list):
+        case .list(let list):
             return list.map { $0.description }.joined(separator: "")
-        case .Element(let elem):
+        case .xmlElement(let elem):
             if elem.name == rootElementName {
                 return elem.children.map { $0.description }.joined(separator: "")
             }
@@ -697,17 +697,17 @@ extension IndexingError: CustomStringConvertible {
     /// The description for the `IndexingError`.
     public var description: String {
         switch self {
-        case .Attribute(let attr):
+        case .attribute(let attr):
             return "XML Attribute Error: Missing attribute [\"\(attr)\"]"
-        case .AttributeValue(let attr, let value):
+        case .attributeValue(let attr, let value):
             return "XML Attribute Error: Missing attribute [\"\(attr)\"] with value [\"\(value)\"]"
-        case .Key(let key):
+        case .key(let key):
             return "XML Element Error: Incorrect key [\"\(key)\"]"
-        case .Index(let index):
+        case .index(let index):
             return "XML Element Error: Incorrect index [\"\(index)\"]"
-        case .Init(let instance):
+        case .init(let instance):
             return "XML Indexer Error: initialization with Object [\"\(instance)\"]"
-        case .Error:
+        case .error:
             return "Unknown Error"
         }
     }

--- a/Tests/SWXMLHashTests/LazyWhiteSpaceParsingTests.swift
+++ b/Tests/SWXMLHashTests/LazyWhiteSpaceParsingTests.swift
@@ -47,11 +47,11 @@ class LazyWhiteSpaceParsingTests: XCTestCase {
 
     // issue #6
     func testShouldBeAbleToPullTextBetweenElementsWithoutWhitespace() {
-        XCTAssertEqual(xml!["niotemplate"]["section"][0]["constraint"][1].element?.text, "H:|-15-[title]-15-|")
+        XCTAssertEqual(xml!["niotemplate"]["section"][0]["constraint"][1].xmlElement?.text, "H:|-15-[title]-15-|")
     }
 
     func testShouldBeAbleToCorrectlyParseCDATASectionsWithWhitespace() {
-        XCTAssertEqual(xml!["niotemplate"]["other"].element?.text, "\n        \n  this\n  has\n  white\n  space\n        \n    ")
+        XCTAssertEqual(xml!["niotemplate"]["other"].xmlElement?.text, "\n        \n  this\n  has\n  white\n  space\n        \n    ")
     }
 }
 

--- a/Tests/SWXMLHashTests/LazyXMLParsingTests.swift
+++ b/Tests/SWXMLHashTests/LazyXMLParsingTests.swift
@@ -40,21 +40,21 @@ class LazyXMLParsingTests: XCTestCase {
     }
 
     func testShouldBeAbleToParseIndividualElements() {
-        XCTAssertEqual(xml!["root"]["header"]["title"].element?.text, "Test Title Header")
+        XCTAssertEqual(xml!["root"]["header"]["title"].xmlElement?.text, "Test Title Header")
     }
 
     func testShouldBeAbleToParseElementGroups() {
-        XCTAssertEqual(xml!["root"]["catalog"]["book"][1]["author"].element?.text, "Ralls, Kim")
+        XCTAssertEqual(xml!["root"]["catalog"]["book"][1]["author"].xmlElement?.text, "Ralls, Kim")
     }
 
     func testShouldBeAbleToParseAttributes() {
-        XCTAssertEqual(xml!["root"]["catalog"]["book"][1].element?.attributes["id"], "bk102")
-        XCTAssertEqual(xml!["root"]["catalog"]["book"][1].element?.attribute(by: "id")?.text, "bk102")
+        XCTAssertEqual(xml!["root"]["catalog"]["book"][1].xmlElement?.attributes["id"], "bk102")
+        XCTAssertEqual(xml!["root"]["catalog"]["book"][1].xmlElement?.attribute(by: "id")?.text, "bk102")
     }
 
     func testShouldBeAbleToLookUpElementsByNameAndAttribute() {
         do {
-            let value = try xml!["root"]["catalog"]["book"].withAttr("id", "bk102")["author"].element?.text
+            let value = try xml!["root"]["catalog"]["book"].withAttr("id", "bk102")["author"].xmlElement?.text
             XCTAssertEqual(value, "Ralls, Kim")
         } catch {
             XCTFail("\(error)")
@@ -62,7 +62,7 @@ class LazyXMLParsingTests: XCTestCase {
     }
 
     func testShouldBeAbleToIterateElementGroups() {
-        let result = xml!["root"]["catalog"]["book"].all.map({ $0["genre"].element!.text! }).joined(separator: ", ")
+        let result = xml!["root"]["catalog"]["book"].all.map({ $0["genre"].xmlElement!.text! }).joined(separator: ", ")
         XCTAssertEqual(result, "Computer, Fantasy, Fantasy")
     }
 
@@ -71,7 +71,7 @@ class LazyXMLParsingTests: XCTestCase {
     }
 
     func testShouldBeAbleToIndexElementGroupsEvenIfOnlyOneElementIsFound() {
-        XCTAssertEqual(xml!["root"]["header"]["title"][0].element?.text, "Test Title Header")
+        XCTAssertEqual(xml!["root"]["header"]["title"][0].xmlElement?.text, "Test Title Header")
     }
 
     func testShouldBeAbleToIterateUsingForIn() {
@@ -84,19 +84,19 @@ class LazyXMLParsingTests: XCTestCase {
     }
 
     func testShouldBeAbleToEnumerateChildren() {
-        let result = xml!["root"]["catalog"]["book"][0].children.map({ $0.element!.name }).joined(separator: ", ")
+        let result = xml!["root"]["catalog"]["book"][0].children.map({ $0.xmlElement!.name }).joined(separator: ", ")
         XCTAssertEqual(result, "author, title, genre, price, publish_date, description")
     }
 
     func testShouldBeAbleToHandleMixedContent() {
-        XCTAssertEqual(xml!["root"]["header"].element?.text, "header mixed contentmore mixed content")
+        XCTAssertEqual(xml!["root"]["header"].xmlElement?.text, "header mixed contentmore mixed content")
     }
 
     func testShouldHandleInterleavingXMLElements() {
         let interleavedXml = "<html><body><p>one</p><div>two</div><p>three</p><div>four</div></body></html>"
         let parsed = SWXMLHash.parse(interleavedXml)
 
-        let result = parsed["html"]["body"].children.map({ $0.element!.text! }).joined(separator: ", ")
+        let result = parsed["html"]["body"].children.map({ $0.xmlElement!.text! }).joined(separator: ", ")
         XCTAssertEqual(result, "one, two, three, four")
     }
 
@@ -110,7 +110,7 @@ class LazyXMLParsingTests: XCTestCase {
     // error handling
 
     func testShouldReturnNilWhenKeysDontMatch() {
-        XCTAssertNil(xml!["root"]["what"]["header"]["foo"].element?.name)
+        XCTAssertNil(xml!["root"]["what"]["header"]["foo"].xmlElement?.name)
     }
 }
 

--- a/Tests/SWXMLHashTests/SWXMLHashConfigTests.swift
+++ b/Tests/SWXMLHashTests/SWXMLHashConfigTests.swift
@@ -43,7 +43,7 @@ class SWXMLHashConfigTests: XCTestCase {
     }
 
     func testShouldAllowProcessingNamespacesOrNot() {
-        XCTAssertEqual(parser!["root"]["table"]["tr"]["td"][0].element?.text, "Apples")
+        XCTAssertEqual(parser!["root"]["table"]["tr"]["td"][0].xmlElement?.text, "Apples")
     }
 }
 

--- a/Tests/SWXMLHashTests/WhiteSpaceParsingTests.swift
+++ b/Tests/SWXMLHashTests/WhiteSpaceParsingTests.swift
@@ -46,11 +46,11 @@ class WhiteSpaceParsingTests: XCTestCase {
 
     // issue #6
     func testShouldBeAbleToPullTextBetweenElementsWithoutWhitespace() {
-        XCTAssertEqual(xml!["niotemplate"]["section"][0]["constraint"][1].element?.text, "H:|-15-[title]-15-|")
+        XCTAssertEqual(xml!["niotemplate"]["section"][0]["constraint"][1].xmlElement?.text, "H:|-15-[title]-15-|")
     }
 
     func testShouldBeAbleToCorrectlyParseCDATASectionsWithWhitespace() {
-        XCTAssertEqual(xml!["niotemplate"]["other"].element?.text, "\n        \n  this\n  has\n  white\n  space\n        \n    ")
+        XCTAssertEqual(xml!["niotemplate"]["other"].xmlElement?.text, "\n        \n  this\n  has\n  white\n  space\n        \n    ")
     }
 }
 

--- a/Tests/SWXMLHashTests/XMLParsingTests.swift
+++ b/Tests/SWXMLHashTests/XMLParsingTests.swift
@@ -40,21 +40,21 @@ class XMLParsingTests: XCTestCase {
     }
 
     func testShouldBeAbleToParseIndividualElements() {
-        XCTAssertEqual(xml!["root"]["header"]["title"].element?.text, "Test Title Header")
+        XCTAssertEqual(xml!["root"]["header"]["title"].xmlElement?.text, "Test Title Header")
     }
 
     func testShouldBeAbleToParseElementGroups() {
-        XCTAssertEqual(xml!["root"]["catalog"]["book"][1]["author"].element?.text, "Ralls, Kim")
+        XCTAssertEqual(xml!["root"]["catalog"]["book"][1]["author"].xmlElement?.text, "Ralls, Kim")
     }
 
     func testShouldBeAbleToParseAttributes() {
-        XCTAssertEqual(xml!["root"]["catalog"]["book"][1].element?.attributes["id"], "bk102")
-        XCTAssertEqual(xml!["root"]["catalog"]["book"][1].element?.attribute(by: "id")?.text, "bk102")
+        XCTAssertEqual(xml!["root"]["catalog"]["book"][1].xmlElement?.attributes["id"], "bk102")
+        XCTAssertEqual(xml!["root"]["catalog"]["book"][1].xmlElement?.attribute(by: "id")?.text, "bk102")
     }
 
     func testShouldBeAbleToLookUpElementsByNameAndAttribute() {
         do {
-            let value = try xml!["root"]["catalog"]["book"].withAttr("id", "bk102")["author"].element?.text
+            let value = try xml!["root"]["catalog"]["book"].withAttr("id", "bk102")["author"].xmlElement?.text
             XCTAssertEqual(value, "Ralls, Kim")
         } catch {
             XCTFail("\(error)")
@@ -63,7 +63,7 @@ class XMLParsingTests: XCTestCase {
     }
 
     func testShouldBeAbleToIterateElementGroups() {
-        let result = xml!["root"]["catalog"]["book"].all.map({ $0["genre"].element!.text! }).joined(separator: ", ")
+        let result = xml!["root"]["catalog"]["book"].all.map({ $0["genre"].xmlElement!.text! }).joined(separator: ", ")
         XCTAssertEqual(result, "Computer, Fantasy, Fantasy")
     }
 
@@ -72,7 +72,7 @@ class XMLParsingTests: XCTestCase {
     }
 
     func testShouldBeAbleToIndexElementGroupsEvenIfOnlyOneElementIsFound() {
-        XCTAssertEqual(xml!["root"]["header"]["title"][0].element?.text, "Test Title Header")
+        XCTAssertEqual(xml!["root"]["header"]["title"][0].xmlElement?.text, "Test Title Header")
     }
 
     func testShouldBeAbleToIterateUsingForIn() {
@@ -85,18 +85,18 @@ class XMLParsingTests: XCTestCase {
     }
 
     func testShouldBeAbleToEnumerateChildren() {
-        let result = xml!["root"]["catalog"]["book"][0].children.map({ $0.element!.name }).joined(separator: ", ")
+        let result = xml!["root"]["catalog"]["book"][0].children.map({ $0.xmlElement!.name }).joined(separator: ", ")
         XCTAssertEqual(result, "author, title, genre, price, publish_date, description")
     }
 
     func testShouldBeAbleToHandleMixedContent() {
-        XCTAssertEqual(xml!["root"]["header"].element?.text, "header mixed contentmore mixed content")
+        XCTAssertEqual(xml!["root"]["header"].xmlElement?.text, "header mixed contentmore mixed content")
     }
 
     func testShouldBeAbleToIterateOverMixedContent() {
         let mixedContentXml = "<html><body><p>mixed content <i>iteration</i> support</body></html>"
         let parsed = SWXMLHash.parse(mixedContentXml)
-        let element = parsed["html"]["body"]["p"].element
+        let element = parsed["html"]["body"]["p"].xmlElement
         XCTAssertNotNil(element)
         if let element = element {
             let result = element.children.reduce("") { acc, child in
@@ -137,7 +137,7 @@ class XMLParsingTests: XCTestCase {
         ]
 
         for (index, mixedContentXml) in mixedContentXmlInputs.enumerated() {
-            XCTAssertEqual(SWXMLHash.parse(mixedContentXml).element!.recursiveText, recursiveTextOutputs[index])
+            XCTAssertEqual(SWXMLHash.parse(mixedContentXml).xmlElement!.recursiveText, recursiveTextOutputs[index])
         }
     }
 
@@ -145,7 +145,7 @@ class XMLParsingTests: XCTestCase {
         let interleavedXml = "<html><body><p>one</p><div>two</div><p>three</p><div>four</div></body></html>"
         let parsed = SWXMLHash.parse(interleavedXml)
 
-        let result = parsed["html"]["body"].children.map({ $0.element!.text! }).joined(separator: ", ")
+        let result = parsed["html"]["body"].children.map({ $0.xmlElement!.text! }).joined(separator: ", ")
         XCTAssertEqual(result, "one, two, three, four")
     }
 
@@ -159,7 +159,7 @@ class XMLParsingTests: XCTestCase {
     // error handling
 
     func testShouldReturnNilWhenKeysDontMatch() {
-        XCTAssertNil(xml!["root"]["what"]["header"]["foo"].element?.name)
+        XCTAssertNil(xml!["root"]["what"]["header"]["foo"].xmlElement?.name)
     }
 
     func testShouldProvideAnErrorObjectWhenKeysDontMatch() {
@@ -189,7 +189,7 @@ class XMLParsingTests: XCTestCase {
     func testShouldStillReturnErrorsWhenAccessingViaSubscripting() {
         var err: IndexingError? = nil
         switch xml!["what"]["subelement"][5]["nomatch"] {
-        case .XMLError(let error):
+        case .xmlError(let error):
             err = error
         default:
             err = nil


### PR DESCRIPTION
to conform to Swift 3 API naming guidelines and work around a Swift 4 compilation issue: https://bugs.swift.org/browse/SR-4951