### PR TITLE
add case-insensitive mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,14 @@ matrix:
         - WORKSPACE="-workspace SWXMLHash.xcworkspace"
         - XCODE_ACTION="build-for-testing test-without-building"
       os: osx
-      osx_image: xcode8
+      osx_image: xcode8.3
       language: objective-c
     - script:
         - swift build
         - swift test
       env: JOB=SPM
       os: osx
-      osx_image: xcode8
+      osx_image: xcode8.3
       language: objective-c
     - script:
         - swift build

--- a/Tests/SWXMLHashTests/XMLParsingTests.swift
+++ b/Tests/SWXMLHashTests/XMLParsingTests.swift
@@ -58,8 +58,20 @@ class XMLParsingTests: XCTestCase {
         } catch {
             XCTFail("\(error)")
         }
-
     }
+    
+    func testShouldBeAbleToLookUpElementsByNameAndAttributeCaseInsensitive() {
+        do {
+            let xmlInsensitive = SWXMLHash.config({ (config) in
+                config.caseInsensitive = true
+            }).parse(xmlToParse)
+            let value = try xmlInsensitive["rOOt"]["catalOg"]["bOOk"].withAttribute("iD", "Bk102")["authOr"].element?.text
+            XCTAssertEqual(value, "Ralls, Kim")
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+
 
     func testShouldBeAbleToIterateElementGroups() {
         let result = xml!["root"]["catalog"]["book"].all.map({ $0["genre"].element!.text }).joined(separator: ", ")


### PR DESCRIPTION
Useful for matching/navigating xml document in a case-insensitive way (it does not affect parsing) #136

I had to add this for a project where server-side can't guarantee predictable casing. 
i.e.

```xml
<section>
  <ParaM kind="person" age="33" />
  <Param kind="persoN" age="34" />
</section>
```

I also thought there are more efficient ways to do this like lowercasing values in parse however it would mean to loose information which is particularly important in the case of attribute and element values.