### PR TITLE
Fix byIndex off by one error

### DIFF
--- a/Source/SWXMLHash.swift
+++ b/Source/SWXMLHash.swift
@@ -676,7 +676,7 @@ public enum XMLIndexer {
             opStream.ops[opStream.ops.count - 1].index = index
             return .stream(opStream)
         case .list(let list):
-            if index <= list.count {
+            if index < list.count {
                 return .element(list[index])
             }
             return .xmlError(IndexingError.index(idx: index))

--- a/Tests/SWXMLHashTests/LazyXMLParsingTests.swift
+++ b/Tests/SWXMLHashTests/LazyXMLParsingTests.swift
@@ -29,7 +29,36 @@ import XCTest
 // swiftlint:disable line_length
 
 class LazyXMLParsingTests: XCTestCase {
-    let xmlToParse = "<root><header>header mixed content<title>Test Title Header</title>more mixed content</header><catalog><book id=\"bk101\"><author>Gambardella, Matthew</author><title>XML Developer's Guide</title><genre>Computer</genre><price>44.95</price><publish_date>2000-10-01</publish_date><description>An in-depth look at creating applications with XML.</description></book><book id=\"bk102\"><author>Ralls, Kim</author><title>Midnight Rain</title><genre>Fantasy</genre><price>5.95</price><publish_date>2000-12-16</publish_date><description>A former architect battles corporate zombies, an evil sorceress, and her own childhood to become queen of the world.</description></book><book id=\"bk103\"><author>Corets, Eva</author><title>Maeve Ascendant</title><genre>Fantasy</genre><price>5.95</price><publish_date>2000-11-17</publish_date><description>After the collapse of a nanotechnology society in England, the young survivors lay the foundation for a new society.</description></book></catalog></root>"
+    let xmlToParse = """
+        <root>
+          <header>header mixed content<title>Test Title Header</title>more mixed content</header>
+          <catalog>
+            <book id=\"bk101\">
+              <author>Gambardella, Matthew</author>
+              <title>XML Developer's Guide</title>
+              <genre>Computer</genre><price>44.95</price>
+              <publish_date>2000-10-01</publish_date>
+              <description>An in-depth look at creating applications with XML.</description>
+            </book>
+            <book id=\"bk102\">
+              <author>Ralls, Kim</author>
+              <title>Midnight Rain</title>
+              <genre>Fantasy</genre>
+              <price>5.95</price>
+              <publish_date>2000-12-16</publish_date>
+              <description>A former architect battles corporate zombies, an evil sorceress, and her own childhood to become queen of the world.</description>
+            </book>
+            <book id=\"bk103\">
+              <author>Corets, Eva</author>
+              <title>Maeve Ascendant</title>
+              <genre>Fantasy</genre>
+              <price>5.95</price>
+              <publish_date>2000-11-17</publish_date>
+              <description>After the collapse of a nanotechnology society in England, the young survivors lay the foundation for a new society.</description>
+            </book>
+          </catalog>
+        </root>
+    """
 
     var xml: XMLIndexer?
 

--- a/Tests/SWXMLHashTests/XMLParsingTests.swift
+++ b/Tests/SWXMLHashTests/XMLParsingTests.swift
@@ -29,7 +29,36 @@ import XCTest
 // swiftlint:disable line_length
 
 class XMLParsingTests: XCTestCase {
-    let xmlToParse = "<root><header>header mixed content<title>Test Title Header</title>more mixed content</header><catalog><book id=\"bk101\"><author>Gambardella, Matthew</author><title>XML Developer's Guide</title><genre>Computer</genre><price>44.95</price><publish_date>2000-10-01</publish_date><description>An in-depth look at creating applications with XML.</description></book><book id=\"bk102\"><author>Ralls, Kim</author><title>Midnight Rain</title><genre>Fantasy</genre><price>5.95</price><publish_date>2000-12-16</publish_date><description>A former architect battles corporate zombies, an evil sorceress, and her own childhood to become queen of the world.</description></book><book id=\"bk103\"><author>Corets, Eva</author><title>Maeve Ascendant</title><genre>Fantasy</genre><price>5.95</price><publish_date>2000-11-17</publish_date><description>After the collapse of a nanotechnology society in England, the young survivors lay the foundation for a new society.</description></book></catalog></root>"
+    let xmlToParse = """
+        <root>
+          <header>header mixed content<title>Test Title Header</title>more mixed content</header>
+          <catalog>
+            <book id=\"bk101\">
+              <author>Gambardella, Matthew</author>
+              <title>XML Developer's Guide</title>
+              <genre>Computer</genre><price>44.95</price>
+              <publish_date>2000-10-01</publish_date>
+              <description>An in-depth look at creating applications with XML.</description>
+            </book>
+            <book id=\"bk102\">
+              <author>Ralls, Kim</author>
+              <title>Midnight Rain</title>
+              <genre>Fantasy</genre>
+              <price>5.95</price>
+              <publish_date>2000-12-16</publish_date>
+              <description>A former architect battles corporate zombies, an evil sorceress, and her own childhood to become queen of the world.</description>
+            </book>
+            <book id=\"bk103\">
+              <author>Corets, Eva</author>
+              <title>Maeve Ascendant</title>
+              <genre>Fantasy</genre>
+              <price>5.95</price>
+              <publish_date>2000-11-17</publish_date>
+              <description>After the collapse of a nanotechnology society in England, the young survivors lay the foundation for a new society.</description>
+            </book>
+          </catalog>
+        </root>
+    """
 
     var xml: XMLIndexer?
 
@@ -46,6 +75,14 @@ class XMLParsingTests: XCTestCase {
 
     func testShouldBeAbleToParseElementGroups() {
         XCTAssertEqual(xml!["root"]["catalog"]["book"][1]["author"].element?.text, "Ralls, Kim")
+    }
+
+    func testShouldBeAbleToParseElementGroupsByIndex() {
+        XCTAssertEqual(try xml!["root"]["catalog"]["book"].byIndex(1)["author"].element?.text, "Ralls, Kim")
+    }
+
+    func testShouldBeAbleToByIndexWithoutGoingOutOfBounds() {
+        XCTAssertEqual(try xml!["root"]["catalog"]["book"].byIndex(3)["author"].element?.text, nil)
     }
 
     func testShouldBeAbleToParseAttributes() {


### PR DESCRIPTION
Added tests to prove prior incorrect behavior as well as additional `byIndex` tests.

Fixes #155.