### PR TITLE
Fix `XMLIndexer.byKey(_:)`

### DIFF
--- a/Source/SWXMLHash.swift
+++ b/Source/SWXMLHash.swift
@@ -641,7 +641,7 @@ public enum XMLIndexer {
                     return .list(match)
                 }
             }
-            return .xmlError(IndexingError.key(key: key))
+            throw IndexingError.key(key: key)
         default:
             throw IndexingError.key(key: key)
         }


### PR DESCRIPTION
It was broken at 8eaaf6d

This will fix failing tests on https://github.com/jpsim/SourceKitten/pull/437