### PR TITLE
Move playground from xcodeproj to xcworkspace

### DIFF
--- a/SWXMLHash.xcodeproj/project.pbxproj
+++ b/SWXMLHash.xcodeproj/project.pbxproj
@@ -138,7 +138,6 @@
 		CDC6D13A1D32D84900570DE5 /* TypeConversionComplexTypesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeConversionComplexTypesTests.swift; sourceTree = "<group>"; };
 		CDC6D13E1D32D98400570DE5 /* TypeConversionPrimitypeTypesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeConversionPrimitypeTypesTests.swift; sourceTree = "<group>"; };
 		CDC6D1421D32D9D200570DE5 /* TypeConversionArrayOfNonPrimitiveTypesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeConversionArrayOfNonPrimitiveTypesTests.swift; sourceTree = "<group>"; };
-		CDD367381A2584A400807984 /* SWXMLHashPlayground.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = SWXMLHashPlayground.playground; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		CDDEC74C1BF6311A00AB138B /* SWXMLHash.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SWXMLHash.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CDDEC7551BF6311B00AB138B /* SWXMLHash tvOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SWXMLHash tvOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CDDEC7681BF6316C00AB138B /* SWXMLHash.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SWXMLHash.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -210,7 +209,6 @@
 		CD6083E5196CA106000B4F8D = {
 			isa = PBXGroup;
 			children = (
-				CDD367381A2584A400807984 /* SWXMLHashPlayground.playground */,
 				CD6083F1196CA106000B4F8D /* Source */,
 				CD6083FE196CA106000B4F8D /* Tests */,
 				CD6083F0196CA106000B4F8D /* Products */,

--- a/SWXMLHash.xcworkspace/contents.xcworkspacedata
+++ b/SWXMLHash.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,9 @@
 <Workspace
    version = "1.0">
    <FileRef
+      location = "group:SWXMLHashPlayground.playground">
+   </FileRef>
+   <FileRef
       location = "container:SWXMLHash.xcodeproj">
    </FileRef>
 </Workspace>


### PR DESCRIPTION
This avoids the problem of Xcode crashing when executing `Convert> To Current Swift Syntax ...` in a project using `SWXMLHash.xcodeproj`.