### PR TITLE
Add userInfo support

### DIFF
--- a/Source/SWXMLHash.swift
+++ b/Source/SWXMLHash.swift
@@ -50,6 +50,9 @@ public class SWXMLHashOptions {
 
     /// Encoding used for XML parsing. Default is set to UTF8
     public var encoding = String.Encoding.utf8
+
+    /// Any contextual information set by the user for encoding
+    public var userInfo = [CodingUserInfoKey: Any]()
 }
 
 /// Simple XML parser
@@ -252,6 +255,7 @@ class LazyXMLParser: NSObject, SimpleXmlParser, XMLParserDelegate {
     required init(_ options: SWXMLHashOptions) {
         self.options = options
         self.root.caseInsensitive = options.caseInsensitive
+        self.root.userInfo = options.userInfo
         super.init()
     }
 
@@ -340,6 +344,7 @@ class FullXMLParser: NSObject, SimpleXmlParser, XMLParserDelegate {
     required init(_ options: SWXMLHashOptions) {
         self.options = options
         self.root.caseInsensitive = options.caseInsensitive
+        self.root.userInfo = options.userInfo
         super.init()
     }
 
@@ -554,6 +559,15 @@ public enum XMLIndexer {
             }
         }
         return list
+    }
+
+    public var userInfo: [CodingUserInfoKey: Any] {
+        switch self {
+        case .element(let elem):
+            return elem.userInfo
+        default:
+            return [:]
+        }
     }
 
     /**
@@ -775,11 +789,15 @@ public class XMLElement: XMLContent {
     /// The name of the element
     public let name: String
 
+    /// Whether the element is case insensitive or not
     public var caseInsensitive: Bool
+
+    var userInfo = [CodingUserInfoKey: Any]()
 
     /// All attributes
     public var allAttributes = [String: XMLAttribute]()
 
+    /// Find an attribute by name
     public func attribute(by name: String) -> XMLAttribute? {
         if caseInsensitive {
             return allAttributes.first(where: { $0.key.compare(name, true) })?.value
@@ -813,6 +831,7 @@ public class XMLElement: XMLContent {
 
     /// All child elements (text or XML)
     public var children = [XMLContent]()
+
     var count: Int = 0
     var index: Int
 
@@ -827,10 +846,11 @@ public class XMLElement: XMLContent {
         - name: The name of the element to be initialized
         - index: The index of the element to be initialized
     */
-    init(name: String, index: Int = 0, caseInsensitive: Bool) {
+    init(name: String, index: Int = 0, caseInsensitive: Bool, userInfo: [CodingUserInfoKey: Any] = [:]) {
         self.name = name
         self.caseInsensitive = caseInsensitive
         self.index = index
+        self.userInfo = userInfo
     }
 
     /**
@@ -843,7 +863,7 @@ public class XMLElement: XMLContent {
     */
 
     func addElement(_ name: String, withAttributes attributes: [String: String], caseInsensitive: Bool) -> XMLElement {
-        let element = XMLElement(name: name, index: count, caseInsensitive: caseInsensitive)
+        let element = XMLElement(name: name, index: count, caseInsensitive: caseInsensitive, userInfo: userInfo)
         count += 1
 
         children.append(element)

--- a/Source/SWXMLHash.swift
+++ b/Source/SWXMLHash.swift
@@ -253,13 +253,12 @@ extension XMLParserDelegate {
 /// The implementation of XMLParserDelegate and where the lazy parsing actually happens.
 class LazyXMLParser: NSObject, SimpleXmlParser, XMLParserDelegate {
     required init(_ options: SWXMLHashOptions) {
+        root = XMLElement(name: rootElementName, options: options)
         self.options = options
-        self.root.caseInsensitive = options.caseInsensitive
-        self.root.userInfo = options.userInfo
         super.init()
     }
 
-    var root = XMLElement(name: rootElementName, caseInsensitive: false)
+    let root: XMLElement
     var parentStack = Stack<XMLElement>()
     var elementStack = Stack<String>()
 
@@ -276,7 +275,6 @@ class LazyXMLParser: NSObject, SimpleXmlParser, XMLParserDelegate {
         // clear any prior runs of parse... expected that this won't be necessary,
         // but you never know
         parentStack.removeAll()
-        root = XMLElement(name: rootElementName, caseInsensitive: options.caseInsensitive)
         parentStack.push(root)
 
         self.ops = ops
@@ -342,13 +340,12 @@ class LazyXMLParser: NSObject, SimpleXmlParser, XMLParserDelegate {
 /// The implementation of XMLParserDelegate and where the parsing actually happens.
 class FullXMLParser: NSObject, SimpleXmlParser, XMLParserDelegate {
     required init(_ options: SWXMLHashOptions) {
+        root = XMLElement(name: rootElementName, options: options)
         self.options = options
-        self.root.caseInsensitive = options.caseInsensitive
-        self.root.userInfo = options.userInfo
         super.init()
     }
 
-    var root = XMLElement(name: rootElementName, caseInsensitive: false)
+    let root: XMLElement
     var parentStack = Stack<XMLElement>()
     let options: SWXMLHashOptions
 
@@ -790,9 +787,13 @@ public class XMLElement: XMLContent {
     public let name: String
 
     /// Whether the element is case insensitive or not
-    public var caseInsensitive: Bool
+    public var caseInsensitive: Bool {
+        return options.caseInsensitive
+    }
 
-    var userInfo = [CodingUserInfoKey: Any]()
+    var userInfo: [CodingUserInfoKey: Any] {
+        return options.userInfo
+    }
 
     /// All attributes
     public var allAttributes = [String: XMLAttribute]()
@@ -834,6 +835,7 @@ public class XMLElement: XMLContent {
 
     var count: Int = 0
     var index: Int
+    let options: SWXMLHashOptions
 
     var xmlChildren: [XMLElement] {
         return children.flatMap { $0 as? XMLElement }
@@ -846,11 +848,10 @@ public class XMLElement: XMLContent {
         - name: The name of the element to be initialized
         - index: The index of the element to be initialized
     */
-    init(name: String, index: Int = 0, caseInsensitive: Bool, userInfo: [CodingUserInfoKey: Any] = [:]) {
+    init(name: String, index: Int = 0, options: SWXMLHashOptions) {
         self.name = name
-        self.caseInsensitive = caseInsensitive
         self.index = index
-        self.userInfo = userInfo
+        self.options = options
     }
 
     /**
@@ -863,7 +864,7 @@ public class XMLElement: XMLContent {
     */
 
     func addElement(_ name: String, withAttributes attributes: [String: String], caseInsensitive: Bool) -> XMLElement {
-        let element = XMLElement(name: name, index: count, caseInsensitive: caseInsensitive, userInfo: userInfo)
+        let element = XMLElement(name: name, index: count, options: options)
         count += 1
 
         children.append(element)

--- a/Tests/SWXMLHashTests/LazyTypesConversionTests.swift
+++ b/Tests/SWXMLHashTests/LazyTypesConversionTests.swift
@@ -66,13 +66,28 @@ class LazyTypesConversionTests: XCTestCase {
             XCTFail("\(error)")
         }
     }
+
+    func testShouldBeAbleToGetUserInfoDuringDeserialization() {
+        parser = SWXMLHash.config { config in
+            let options = SampleUserInfo(apiVersion: .v1)
+            config.userInfo = [ SampleUserInfo.key: options ]
+        }.parse(xmlWithBasicTypes)
+
+        do {
+            let value: BasicItem = try parser!["root"]["basicItem"].value()
+            XCTAssertEqual(value.name, "the name of basic item (v1)")
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
 }
 
 extension LazyTypesConversionTests {
     static var allTests: [(String, (LazyTypesConversionTests) -> () throws -> Void)] {
         return [
             ("testShouldConvertValueToNonOptional", testShouldConvertValueToNonOptional),
-            ("testShouldConvertAttributeToNonOptional", testShouldConvertAttributeToNonOptional)
+            ("testShouldConvertAttributeToNonOptional", testShouldConvertAttributeToNonOptional),
+            ("testShouldBeAbleToGetUserInfoDuringDeserialization", testShouldBeAbleToGetUserInfoDuringDeserialization)
         ]
     }
 }


### PR DESCRIPTION
Adds userInfo support (similar to that from `Codable`) - for consistency, it even uses the `CodingUserInfoKey` for the hash.

In addition, I also cleaned up some of the parameters to `XMLElement`.

Fixes #167 