### PR TITLE
Fix CDATA Parsing on Linux

### DIFF
--- a/Source/SWXMLHash.swift
+++ b/Source/SWXMLHash.swift
@@ -312,6 +312,18 @@ class LazyXMLParser: NSObject, SimpleXmlParser, XMLParserDelegate {
         current.addText(string)
     }
 
+    func parser(_ parser: XMLParser, foundCDATA CDATABlock: Data) {
+        if !onMatch() {
+            return
+        }
+
+        if let cdataText = String(data: CDATABlock, encoding: String.Encoding.utf8) {
+            let current = parentStack.top()
+
+            current.addText(cdataText)
+        }
+    }
+
     func parser(_ parser: Foundation.XMLParser,
                 didEndElement elementName: String,
                 namespaceURI: String?,
@@ -390,11 +402,11 @@ class FullXMLParser: NSObject, SimpleXmlParser, XMLParserDelegate {
 
         parentStack.drop()
     }
-    
+
     func parser(_ parser: XMLParser, foundCDATA CDATABlock: Data) {
         if let cdataText = String(data: CDATABlock, encoding: String.Encoding.utf8) {
             let current = parentStack.top()
-            
+
             current.addText(cdataText)
         }
     }

--- a/Source/SWXMLHash.swift
+++ b/Source/SWXMLHash.swift
@@ -390,6 +390,14 @@ class FullXMLParser: NSObject, SimpleXmlParser, XMLParserDelegate {
 
         parentStack.drop()
     }
+    
+    func parser(_ parser: XMLParser, foundCDATA CDATABlock: Data) {
+        if let cdataText = String(data: CDATABlock, encoding: String.Encoding.utf8) {
+            let current = parentStack.top()
+            
+            current.addText(cdataText)
+        }
+    }
 }
 
 /// Represents an indexed operation against a lazily parsed `XMLIndexer`

--- a/Tests/SWXMLHashTests/LazyWhiteSpaceParsingTests.swift
+++ b/Tests/SWXMLHashTests/LazyWhiteSpaceParsingTests.swift
@@ -53,11 +53,7 @@ class LazyWhiteSpaceParsingTests: XCTestCase {
     }
 
     func testShouldBeAbleToCorrectlyParseCDATASectionsWithWhitespace() {
-#if os(Linux)
-        print("Skip \(#function) on Linux")
-#else
         XCTAssertEqual(xml!["niotemplate"]["other"].element?.text, "\n        \n  this\n  has\n  white\n  space\n        \n    ")
-#endif
     }
 }
 

--- a/Tests/SWXMLHashTests/WhiteSpaceParsingTests.swift
+++ b/Tests/SWXMLHashTests/WhiteSpaceParsingTests.swift
@@ -52,11 +52,7 @@ class WhiteSpaceParsingTests: XCTestCase {
     }
 
     func testShouldBeAbleToCorrectlyParseCDATASectionsWithWhitespace() {
-#if os(Linux)
-        print("Skip \(#function) on Linux")
-#else
         XCTAssertEqual(xml!["niotemplate"]["other"].element?.text, "\n        \n  this\n  has\n  white\n  space\n        \n    ")
-#endif
     }
 }
 


### PR DESCRIPTION
It appears that there is a difference between the Linux and Mac implementations of `XMLParser` - on the Mac side of things, the CDATA content gets returned regardless of if the implementation handles the `parser(_:foundCDATA:)` method or not; however, in Linux, it doesn't
return CDATA in `foundCharacters` at all.

Fixes #172 