### PR TITLE
 Rework filter to match all/children methods

### DIFF
--- a/Source/SWXMLHash+TypeConversion.swift
+++ b/Source/SWXMLHash+TypeConversion.swift
@@ -114,6 +114,7 @@ public extension XMLIndexer {
      - returns: The deserialized `T` value
      */
     func value<T: XMLAttributeDeserializable>(ofAttribute attr: String) throws -> T {
+        print("in attribute deserializable (throws)")
         switch self {
         case .element(let element):
             return try element.value(ofAttribute: attr)

--- a/Source/SWXMLHash+TypeConversion.swift
+++ b/Source/SWXMLHash+TypeConversion.swift
@@ -114,7 +114,6 @@ public extension XMLIndexer {
      - returns: The deserialized `T` value
      */
     func value<T: XMLAttributeDeserializable>(ofAttribute attr: String) throws -> T {
-        print("in attribute deserializable (throws)")
         switch self {
         case .element(let element):
             return try element.value(ofAttribute: attr)
@@ -308,7 +307,6 @@ public extension XMLIndexer {
     - throws: an XMLDeserializationError is there is a problem with deserialization
     */
     func value<T: XMLIndexerDeserializable>() throws -> T {
-        print("in XMLIndexerDeserializable returns T")
         switch self {
         case .element:
             return try T.deserialize(self)

--- a/Source/SWXMLHash+TypeConversion.swift
+++ b/Source/SWXMLHash+TypeConversion.swift
@@ -308,6 +308,7 @@ public extension XMLIndexer {
     - throws: an XMLDeserializationError is there is a problem with deserialization
     */
     func value<T: XMLIndexerDeserializable>() throws -> T {
+        print("in XMLIndexerDeserializable returns T")
         switch self {
         case .element:
             return try T.deserialize(self)

--- a/Source/SWXMLHash.swift
+++ b/Source/SWXMLHash.swift
@@ -588,7 +588,13 @@ public enum XMLIndexer {
     }
 
     public func filterChildren(_ included: (_ elem: XMLElement, _ index: Int) -> Bool) -> XMLIndexer {
-        return handleFilteredResults(list: childElements, included: included)
+        let children = handleFilteredResults(list: childElements, included: included)
+        if let current = self.element {
+            let filteredElem = XMLElement(name: current.name, index: current.index, options: current.options)
+            filteredElem.children = children.allElements
+            return .element(filteredElem)
+        }
+        return .xmlError(IndexingError.error)
     }
 
     public func filterAll(_ included: (_ elem: XMLElement, _ index: Int) -> Bool) -> XMLIndexer {

--- a/Source/SWXMLHash.swift
+++ b/Source/SWXMLHash.swift
@@ -596,8 +596,10 @@ public enum XMLIndexer {
                                        included: (_ elem: XMLElement, _ index: Int) -> Bool) -> XMLIndexer {
         let results = zip(list.indices, list).filter { included($1, $0) }.map { $1 }
         if results.count == 1 {
+            print("returning element")
             return .element(results.first!)
         }
+        print("returning list")
         return .list(results)
     }
 

--- a/Tests/SWXMLHashTests/LazyTypesConversionTests.swift
+++ b/Tests/SWXMLHashTests/LazyTypesConversionTests.swift
@@ -37,7 +37,7 @@ class LazyTypesConversionTests: XCTestCase {
           <bool1>0</bool1>
           <bool2>true</bool2>
           <empty></empty>
-          <basicItem>
+          <basicItem id="1234">
             <name>the name of basic item</name>
             <price>99.14</price>
           </basicItem>

--- a/Tests/SWXMLHashTests/LazyXMLParsingTests.swift
+++ b/Tests/SWXMLHashTests/LazyXMLParsingTests.swift
@@ -144,8 +144,8 @@ class LazyXMLParsingTests: XCTestCase {
 
     func testShouldBeAbleToFilterOnIndexer() {
         let subIndexer = xml!["root"]["catalog"]["book"]
-            .filter { elem, _ in elem.attribute(by: "id")!.text == "bk102" }
-            .filter { _, index in index >= 1 && index <= 3 }
+            .filterAll { elem, _ in elem.attribute(by: "id")!.text == "bk102" }
+            .filterChildren { _, index in index >= 1 && index <= 3 }
 
         XCTAssertEqual(subIndexer[0].element?.name, "title")
         XCTAssertEqual(subIndexer[1].element?.name, "genre")

--- a/Tests/SWXMLHashTests/LazyXMLParsingTests.swift
+++ b/Tests/SWXMLHashTests/LazyXMLParsingTests.swift
@@ -136,8 +136,6 @@ class LazyXMLParsingTests: XCTestCase {
         XCTAssertEqual(parsed.description, "<root><foo><what id=\"myId\">puppies</what></foo></root>")
     }
 
-    // error handling
-
     func testShouldReturnNilWhenKeysDontMatch() {
         XCTAssertNil(xml!["root"]["what"]["header"]["foo"].element?.name)
     }
@@ -147,13 +145,13 @@ class LazyXMLParsingTests: XCTestCase {
             .filterAll { elem, _ in elem.attribute(by: "id")!.text == "bk102" }
             .filterChildren { _, index in index >= 1 && index <= 3 }
 
-        XCTAssertEqual(subIndexer[0].element?.name, "title")
-        XCTAssertEqual(subIndexer[1].element?.name, "genre")
-        XCTAssertEqual(subIndexer[2].element?.name, "price")
+        XCTAssertEqual(subIndexer.children[0].element?.name, "title")
+        XCTAssertEqual(subIndexer.children[1].element?.name, "genre")
+        XCTAssertEqual(subIndexer.children[2].element?.name, "price")
 
-        XCTAssertEqual(subIndexer[0].element?.text, "Midnight Rain")
-        XCTAssertEqual(subIndexer[1].element?.text, "Fantasy")
-        XCTAssertEqual(subIndexer[2].element?.text, "5.95")
+        XCTAssertEqual(subIndexer.children[0].element?.text, "Midnight Rain")
+        XCTAssertEqual(subIndexer.children[1].element?.text, "Fantasy")
+        XCTAssertEqual(subIndexer.children[2].element?.text, "5.95")
     }
 }
 

--- a/Tests/SWXMLHashTests/TypeConversionArrayOfNonPrimitiveTypesTests.swift
+++ b/Tests/SWXMLHashTests/TypeConversionArrayOfNonPrimitiveTypesTests.swift
@@ -215,7 +215,7 @@ class TypeConversionArrayOfNonPrimitiveTypesTests: XCTestCase {
 
     func testFilterWithAttributesShouldWork() {
         do {
-            let subParser = parser!["root"]["arrayOfGoodAttributeItems"].filterChildren { _, idx in idx > 0 }
+            let subParser = parser!["root"]["arrayOfGoodAttributeItems"]["attributeItem"].filterAll { _, idx in idx > 0 }
 
             let values: [AttributeItem] = try subParser.value()
 
@@ -231,7 +231,7 @@ class TypeConversionArrayOfNonPrimitiveTypesTests: XCTestCase {
 
     func testFilterAndSerializationSingleShouldWork() {
         do {
-            let subParser = parser!["root"]["arrayOfGoodBasicItems"].filterChildren { _, idx in idx == 0 }
+            let subParser = parser!["root"]["arrayOfGoodBasicItems"]["basicItem"].filterAll { _, idx in idx == 0 }
 
             let value: BasicItem = try subParser.value()
 
@@ -245,7 +245,7 @@ class TypeConversionArrayOfNonPrimitiveTypesTests: XCTestCase {
 
     func testFilterAndSerializationShouldWork() {
         do {
-            let subParser = parser!["root"]["arrayOfGoodBasicItems"].filterChildren { _, idx in idx > 0 }
+            let subParser = parser!["root"]["arrayOfGoodBasicItems"]["basicItem"].filterAll { _, idx in idx > 0 }
 
             let values: [BasicItem] = try subParser.value()
 

--- a/Tests/SWXMLHashTests/TypeConversionArrayOfNonPrimitiveTypesTests.swift
+++ b/Tests/SWXMLHashTests/TypeConversionArrayOfNonPrimitiveTypesTests.swift
@@ -215,7 +215,7 @@ class TypeConversionArrayOfNonPrimitiveTypesTests: XCTestCase {
 
     func testFilterWithAttributesShouldWork() {
         do {
-            let subParser = parser!["root"]["arrayOfGoodAttributeItems"].filter { _, idx in idx > 0 }
+            let subParser = parser!["root"]["arrayOfGoodAttributeItems"].filterChildren { _, idx in idx > 0 }
 
             let values: [AttributeItem] = try subParser.value()
 
@@ -231,7 +231,7 @@ class TypeConversionArrayOfNonPrimitiveTypesTests: XCTestCase {
 
     func testFilterAndSerializationSingleShouldWork() {
         do {
-            let subParser = parser!["root"]["arrayOfGoodBasicItems"].filter { _, idx in idx == 0 }
+            let subParser = parser!["root"]["arrayOfGoodBasicItems"].filterChildren { _, idx in idx == 0 }
 
             let value: BasicItem = try subParser.value()
 
@@ -245,7 +245,7 @@ class TypeConversionArrayOfNonPrimitiveTypesTests: XCTestCase {
 
     func testFilterAndSerializationShouldWork() {
         do {
-            let subParser = parser!["root"]["arrayOfGoodBasicItems"].filter { _, idx in idx > 0 }
+            let subParser = parser!["root"]["arrayOfGoodBasicItems"].filterChildren { _, idx in idx > 0 }
 
             let values: [BasicItem] = try subParser.value()
 

--- a/Tests/SWXMLHashTests/TypeConversionArrayOfNonPrimitiveTypesTests.swift
+++ b/Tests/SWXMLHashTests/TypeConversionArrayOfNonPrimitiveTypesTests.swift
@@ -34,15 +34,15 @@ class TypeConversionArrayOfNonPrimitiveTypesTests: XCTestCase {
     let xmlWithArraysOfTypes = """
         <root>
           <arrayOfGoodBasicItems>
-            <basicItem>
+            <basicItem id="1234a">
               <name>item 1</name>
               <price>1</price>
             </basicItem>
-            <basicItem>
+            <basicItem id="1234b">
               <name>item 2</name>
               <price>2</price>
             </basicItem>
-            <basicItem>
+            <basicItem id="1234c">
               <name>item 3</name>
               <price>3</price>
             </basicItem>
@@ -75,9 +75,9 @@ class TypeConversionArrayOfNonPrimitiveTypesTests: XCTestCase {
     """
 
     let correctBasicItems = [
-        BasicItem(name: "item 1", price: 1),
-        BasicItem(name: "item 2", price: 2),
-        BasicItem(name: "item 3", price: 3)
+        BasicItem(name: "item 1", price: 1, id: "1234a"),
+        BasicItem(name: "item 2", price: 2, id: "1234b"),
+        BasicItem(name: "item 3", price: 3, id: "1234c")
     ]
 
     let correctAttributeItems = [
@@ -213,13 +213,31 @@ class TypeConversionArrayOfNonPrimitiveTypesTests: XCTestCase {
         }
     }
 
+    func testFilterWithAttributesShouldWork() {
+        do {
+            let subParser = parser!["root"]["arrayOfGoodAttributeItems"].filter { _, idx in idx > 0 }
+
+            let values: [AttributeItem] = try subParser.value()
+
+            XCTAssertNotNil(values)
+            XCTAssertEqual(values[0].name, "attr 2")
+            XCTAssertEqual(values[0].price, 2.2)
+            XCTAssertEqual(values[1].name, "attr 3")
+            XCTAssertEqual(values[1].price, 3.3)
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+
     func testFilterAndSerializationShouldWork() {
         do {
-            let subParser = parser!["root"]["arrayOfGoodBasicItems"].filter({ _, idx in idx == 0 })
+            let subParser = parser!["root"]["arrayOfGoodBasicItems"].filter { _, idx in idx > 0 }
 
-            let value: BasicItem = try subParser.value()
+            let values: [BasicItem] = try subParser.value()
 
-            XCTAssertNotNil(value)
+            XCTAssertNotNil(values)
+            XCTAssertEqual(values[0].id, "1234b")
+            XCTAssertEqual(values[1].id, "1234c")
         } catch {
             XCTFail("\(error)")
         }

--- a/Tests/SWXMLHashTests/TypeConversionArrayOfNonPrimitiveTypesTests.swift
+++ b/Tests/SWXMLHashTests/TypeConversionArrayOfNonPrimitiveTypesTests.swift
@@ -229,6 +229,20 @@ class TypeConversionArrayOfNonPrimitiveTypesTests: XCTestCase {
         }
     }
 
+    func testFilterAndSerializationSingleShouldWork() {
+        do {
+            let subParser = parser!["root"]["arrayOfGoodBasicItems"].filter { _, idx in idx == 0 }
+
+            let value: BasicItem = try subParser.value()
+
+            XCTAssertNotNil(value)
+            XCTAssertEqual(value.id, "1234a")
+            XCTAssertEqual(value.id, "1234a")
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+
     func testFilterAndSerializationShouldWork() {
         do {
             let subParser = parser!["root"]["arrayOfGoodBasicItems"].filter { _, idx in idx > 0 }

--- a/Tests/SWXMLHashTests/TypeConversionBasicTypesTests.swift
+++ b/Tests/SWXMLHashTests/TypeConversionBasicTypesTests.swift
@@ -65,7 +65,7 @@ class TypeConversionBasicTypesTests: XCTestCase {
           <bool1>0</bool1>
           <bool2>true</bool2>
           <empty></empty>
-          <basicItem>
+          <basicItem id="1234">
             <name>the name of basic item</name>
             <price>99.14</price>
           </basicItem>
@@ -436,7 +436,7 @@ class TypeConversionBasicTypesTests: XCTestCase {
         XCTAssertEqual(value, true)
     }
 
-    let correctBasicItem = BasicItem(name: "the name of basic item", price: 99.14)
+    let correctBasicItem = BasicItem(name: "the name of basic item", price: 99.14, id: "1234")
 
     func testBasicItemShouldConvertBasicitemToNonOptional() {
         do {
@@ -566,6 +566,7 @@ class TypeConversionBasicTypesTests: XCTestCase {
 struct BasicItem: XMLIndexerDeserializable {
     let name: String
     let price: Double
+    let id: String
 
     static func deserialize(_ node: XMLIndexer) throws -> BasicItem {
         var name: String = try node["name"].value()
@@ -576,7 +577,8 @@ struct BasicItem: XMLIndexerDeserializable {
 
         return try BasicItem(
             name: name,
-            price: node["price"].value()
+            price: node["price"].value(),
+            id: node.value(ofAttribute: "id")
         )
     }
 }
@@ -592,6 +594,7 @@ struct AttributeItem: XMLElementDeserializable {
     let price: Double
 
     static func deserialize(_ element: SWXMLHash.XMLElement) throws -> AttributeItem {
+        print("my deserialize")
         return try AttributeItem(
             name: element.value(ofAttribute: "name"),
             price: element.value(ofAttribute: "price")

--- a/Tests/SWXMLHashTests/TypeConversionComplexTypesTests.swift
+++ b/Tests/SWXMLHashTests/TypeConversionComplexTypesTests.swift
@@ -36,15 +36,15 @@ class TypeConversionComplexTypesTests: XCTestCase {
             <name>the name of complex item</name>
             <price>1024</price>
             <basicItems>
-              <basicItem>
+              <basicItem id="1234a">
                 <name>item 1</name>
                 <price>1</price>
               </basicItem>
-              <basicItem>
+              <basicItem id="1234a">
                 <name>item 2</name>
                 <price>2</price>
               </basicItem>
-              <basicItem>
+              <basicItem id="1234a">
                 <name>item 3</name>
                 <price>3</price>
               </basicItem>
@@ -63,9 +63,9 @@ class TypeConversionComplexTypesTests: XCTestCase {
         name: "the name of complex item",
         priceOptional: 1_024,
         basics: [
-            BasicItem(name: "item 1", price: 1),
-            BasicItem(name: "item 2", price: 2),
-            BasicItem(name: "item 3", price: 3)
+            BasicItem(name: "item 1", price: 1, id: "1234a"),
+            BasicItem(name: "item 2", price: 2, id: "1234b"),
+            BasicItem(name: "item 3", price: 3, id: "1234c")
         ],
         attrs: [
             AttributeItem(name: "attr1", price: 1.1),

--- a/Tests/SWXMLHashTests/XMLParsingTests.swift
+++ b/Tests/SWXMLHashTests/XMLParsingTests.swift
@@ -246,7 +246,7 @@ class XMLParsingTests: XCTestCase {
     }
 
     func testShouldBeAbleToCreateASubIndexer() {
-        let subIndexer = xml!["root"]["catalog"]["book"][1].filter { _, index in index >= 1 && index <= 3 }
+        let subIndexer = xml!["root"]["catalog"]["book"][1].filterChildren { _, index in index >= 1 && index <= 3 }
 
         XCTAssertEqual(subIndexer[0].element?.name, "title")
         XCTAssertEqual(subIndexer[1].element?.name, "genre")
@@ -258,7 +258,7 @@ class XMLParsingTests: XCTestCase {
     }
 
     func testShouldBeAbleToCreateASubIndexerFromFilter() {
-        let subIndexer = xml!["root"]["catalog"]["book"][1].filter { elem, _ in
+        let subIndexer = xml!["root"]["catalog"]["book"][1].filterChildren { elem, _ in
             let filterByNames = ["title", "genre", "price"]
             return filterByNames.contains(elem.name)
         }
@@ -274,8 +274,8 @@ class XMLParsingTests: XCTestCase {
 
     func testShouldBeAbleToFilterOnIndexer() {
         let subIndexer = xml!["root"]["catalog"]["book"]
-            .filter { elem, _ in elem.attribute(by: "id")!.text == "bk102" }
-            .filter { _, index in index >= 1 && index <= 3 }
+            .filterAll { elem, _ in elem.attribute(by: "id")!.text == "bk102" }
+            .filterChildren { _, index in index >= 1 && index <= 3 }
 
         XCTAssertEqual(subIndexer[0].element?.name, "title")
         XCTAssertEqual(subIndexer[1].element?.name, "genre")

--- a/Tests/SWXMLHashTests/XMLParsingTests.swift
+++ b/Tests/SWXMLHashTests/XMLParsingTests.swift
@@ -246,15 +246,32 @@ class XMLParsingTests: XCTestCase {
     }
 
     func testShouldBeAbleToCreateASubIndexer() {
-        let subIndexer = xml!["root"]["catalog"]["book"][1].filterChildren { _, index in index >= 1 && index <= 3 }
+        let xmlToParse = """
+            <root>
+                <some-weird-element />
+                <another-weird-element />
+                <prop1 name="prop1" />
+                <prop2 name="prop2" />
+                <basicItem id="1234a">
+                    <name>item 1</name>
+                    <price>1</price>
+                </basicItem>
+                <prop3 name="prop3" />
+                <last-weird-element />
+            </root>
+        """
 
-        XCTAssertEqual(subIndexer[0].element?.name, "title")
-        XCTAssertEqual(subIndexer[1].element?.name, "genre")
-        XCTAssertEqual(subIndexer[2].element?.name, "price")
+        let parser = SWXMLHash.parse(xmlToParse)
 
-        XCTAssertEqual(subIndexer[0].element?.text, "Midnight Rain")
-        XCTAssertEqual(subIndexer[1].element?.text, "Fantasy")
-        XCTAssertEqual(subIndexer[2].element?.text, "5.95")
+        let subIndexer = parser["root"].filterChildren { _, index in index >= 2 && index <= 5 }
+
+        XCTAssertNil(subIndexer["some-weird-element"].element)
+        XCTAssertNil(subIndexer["another-weird-element"].element)
+        XCTAssertNotNil(subIndexer["prop1"].element)
+        XCTAssertNotNil(subIndexer["prop2"].element)
+        XCTAssertNotNil(subIndexer["basicItem"].element)
+        XCTAssertNotNil(subIndexer["prop3"].element)
+        XCTAssertNil(subIndexer["last-weird-element"].element)
     }
 
     func testShouldBeAbleToCreateASubIndexerFromFilter() {
@@ -263,13 +280,13 @@ class XMLParsingTests: XCTestCase {
             return filterByNames.contains(elem.name)
         }
 
-        XCTAssertEqual(subIndexer[0].element?.name, "title")
-        XCTAssertEqual(subIndexer[1].element?.name, "genre")
-        XCTAssertEqual(subIndexer[2].element?.name, "price")
+        XCTAssertEqual(subIndexer.children[0].element?.name, "title")
+        XCTAssertEqual(subIndexer.children[1].element?.name, "genre")
+        XCTAssertEqual(subIndexer.children[2].element?.name, "price")
 
-        XCTAssertEqual(subIndexer[0].element?.text, "Midnight Rain")
-        XCTAssertEqual(subIndexer[1].element?.text, "Fantasy")
-        XCTAssertEqual(subIndexer[2].element?.text, "5.95")
+        XCTAssertEqual(subIndexer.children[0].element?.text, "Midnight Rain")
+        XCTAssertEqual(subIndexer.children[1].element?.text, "Fantasy")
+        XCTAssertEqual(subIndexer.children[2].element?.text, "5.95")
     }
 
     func testShouldBeAbleToFilterOnIndexer() {
@@ -277,13 +294,13 @@ class XMLParsingTests: XCTestCase {
             .filterAll { elem, _ in elem.attribute(by: "id")!.text == "bk102" }
             .filterChildren { _, index in index >= 1 && index <= 3 }
 
-        XCTAssertEqual(subIndexer[0].element?.name, "title")
-        XCTAssertEqual(subIndexer[1].element?.name, "genre")
-        XCTAssertEqual(subIndexer[2].element?.name, "price")
+        XCTAssertEqual(subIndexer.children[0].element?.name, "title")
+        XCTAssertEqual(subIndexer.children[1].element?.name, "genre")
+        XCTAssertEqual(subIndexer.children[2].element?.name, "price")
 
-        XCTAssertEqual(subIndexer[0].element?.text, "Midnight Rain")
-        XCTAssertEqual(subIndexer[1].element?.text, "Fantasy")
-        XCTAssertEqual(subIndexer[2].element?.text, "5.95")
+        XCTAssertEqual(subIndexer.children[0].element?.text, "Midnight Rain")
+        XCTAssertEqual(subIndexer.children[1].element?.text, "Fantasy")
+        XCTAssertEqual(subIndexer.children[2].element?.text, "5.95")
     }
 }
 


### PR DESCRIPTION
I didn't really think through the implementation of `filter` in my modifications to #174 - as a result, `filter` originally varied in what it filtered on depending on if the indexed level was an element or a list. It wasn't clear or intuitive.

This PR hopefully changes that. Now it should be completely clear which collections are being filtered - `filterAll` filters against the `all` list while `filterChildren` filters against the `children` list.