### PR TITLE
Add Docker support for easier Linux testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM ibmcom/swift-ubuntu:latest
+
+ENV APP_HOME ./app
+RUN mkdir $APP_HOME
+
+WORKDIR $APP_HOME

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+services:
+  app:
+    build: .
+    command: bash
+    volumes:
+      - .:/app
+    tty: true
+    stdin_open: true


### PR DESCRIPTION
Just run `docker-compose run app` to get into a bash instance. To run the tests against Linux, just run `docker-compose run app swift test`.

This is using https://github.com/IBM-Swift/swift-ubuntu-docker which is currently targeting `4.0.3`.