### PR TITLE
Fix cast on Linux with Swift 4.2

### DIFF
--- a/Source/SWXMLHash.swift
+++ b/Source/SWXMLHash.swift
@@ -426,7 +426,7 @@ class FullXMLParser: NSObject, SimpleXmlParser, XMLParserDelegate {
     }
 
     func parser(_ parser: XMLParser, parseErrorOccurred parseError: Error) {
-#if os(Linux)
+#if os(Linux) && !swift(>=4.1.50)
         if let err = parseError as? NSError {
             parsingError = ParsingError(line: err.userInfo["NSXMLParserErrorLineNumber"] as? Int ?? 0,
                                         column: err.userInfo["NSXMLParserErrorColumn"] as? Int ?? 0)


### PR DESCRIPTION
Fixes the following warning on Linux with Swift 4.2 as reported in https://github.com/jpsim/SourceKitten/issues/564

```
Source/SWXMLHash.swift:430:33: warning: conditional cast from 'Error' to 'NSError' always succeeds
if let err = parseError as? NSError {
^
```