### PR TITLE
Fix issue with subsequent lazy parsing calls

### DIFF
--- a/Source/SWXMLHash.swift
+++ b/Source/SWXMLHash.swift
@@ -267,7 +267,7 @@ class LazyXMLParser: NSObject, SimpleXmlParser, XMLParserDelegate {
         super.init()
     }
 
-    let root: XMLElement
+    var root: XMLElement
     var parentStack = Stack<XMLElement>()
     var elementStack = Stack<String>()
 
@@ -281,8 +281,8 @@ class LazyXMLParser: NSObject, SimpleXmlParser, XMLParserDelegate {
     }
 
     func startParsing(_ ops: [IndexOp]) {
-        // clear any prior runs of parse... expected that this won't be necessary,
-        // but you never know
+        // reset state for a new lazy parsing run
+        root = XMLElement(name: rootElementName, options: root.options)
         parentStack.removeAll()
         parentStack.push(root)
 

--- a/Tests/SWXMLHashTests/LazyXMLParsingTests.swift
+++ b/Tests/SWXMLHashTests/LazyXMLParsingTests.swift
@@ -73,6 +73,11 @@ class LazyXMLParsingTests: XCTestCase {
         XCTAssertEqual(xml!["root"]["header"]["title"].element?.text, "Test Title Header")
     }
 
+    func testShouldBeAbleToHandleSubsequentParseCalls() {
+        XCTAssertEqual(xml!["root"]["header"]["title"].element?.text, "Test Title Header")
+        XCTAssertEqual(xml!["root"]["catalog"]["book"][1]["author"].element?.text, "Ralls, Kim")
+    }
+
     func testShouldBeAbleToParseElementGroups() {
         XCTAssertEqual(xml!["root"]["catalog"]["book"][1]["author"].element?.text, "Ralls, Kim")
     }


### PR DESCRIPTION
Only part of the state was being reset between lazy calls. This bug fix
ensures that the root element is also reset.

Fixes #203.