### PR TITLE
String raw representables

### DIFF
--- a/Source/SWXMLHash.swift
+++ b/Source/SWXMLHash.swift
@@ -183,7 +183,6 @@ protocol SimpleXmlParser {
 #if os(Linux)
 
 extension XMLParserDelegate {
-
     func parserDidStartDocument(_ parser: Foundation.XMLParser) { }
     func parserDidEndDocument(_ parser: Foundation.XMLParser) { }
 
@@ -303,7 +302,6 @@ class LazyXMLParser: NSObject, SimpleXmlParser, XMLParserDelegate {
                 namespaceURI: String?,
                 qualifiedName qName: String?,
                 attributes attributeDict: [String: String]) {
-
         elementStack.push(elementName)
 
         if !onMatch() {
@@ -342,7 +340,6 @@ class LazyXMLParser: NSObject, SimpleXmlParser, XMLParserDelegate {
                 didEndElement elementName: String,
                 namespaceURI: String?,
                 qualifiedName qName: String?) {
-
         let match = onMatch()
 
         elementStack.drop()
@@ -400,7 +397,6 @@ class FullXMLParser: NSObject, SimpleXmlParser, XMLParserDelegate {
                 namespaceURI: String?,
                 qualifiedName qName: String?,
                 attributes attributeDict: [String: String]) {
-
         let currentNode = parentStack
             .top()
             .addElement(elementName, withAttributes: attributeDict, caseInsensitive: self.options.caseInsensitive)
@@ -418,7 +414,6 @@ class FullXMLParser: NSObject, SimpleXmlParser, XMLParserDelegate {
                 didEndElement elementName: String,
                 namespaceURI: String?,
                 qualifiedName qName: String?) {
-
         parentStack.drop()
     }
 
@@ -1044,12 +1039,11 @@ fileprivate extension String {
     }
 }
 
-//MARK: - XMLIndexer String RawRepresentables
+// MARK: - XMLIndexer String RawRepresentables
 
 /*: Provides XMLIndexer Serialization/Deserialization using String backed RawRepresentables
     Added by [PeeJWeeJ](https://github.com/PeeJWeeJ) */
 extension XMLIndexer {
-    
     /**
      Allows for element lookup by matching attribute values
      using a String backed RawRepresentables (E.g. `String` backed `enum` cases)
@@ -1063,10 +1057,11 @@ extension XMLIndexer {
      - throws: an XMLIndexer.XMLError if an element with the specified attribute isn't found
      - returns: instance of XMLIndexer
      */
-    public func withAttribute<A: RawRepresentable, V: RawRepresentable>(_ attr: A, _ value: V) throws -> XMLIndexer where A.RawValue == String, V.RawValue == String {
+    public func withAttribute<A: RawRepresentable, V: RawRepresentable>(_ attr: A, _ value: V) throws -> XMLIndexer
+        where A.RawValue == String, V.RawValue == String {
         return try withAttribute(attr.rawValue, value.rawValue)
     }
-    
+
     /**
      Find an XML element at the current level by element name
      using a String backed RawRepresentable (E.g. `String` backed `enum` cases)
@@ -1081,7 +1076,7 @@ extension XMLIndexer {
     public func byKey<K: RawRepresentable>(_ key: K) throws -> XMLIndexer where K.RawValue == String {
         return try byKey(key.rawValue)
     }
-    
+
     /**
      Find an XML element at the current level by element name
      using a String backed RawRepresentable (E.g. `String` backed `enum` cases)
@@ -1092,17 +1087,16 @@ extension XMLIndexer {
      - parameter key: The element name to index by
      - returns: instance of XMLIndexer to match the element (or elements) found by
      */
-    public subscript<K: RawRepresentable>(key: K) -> XMLIndexer where K.RawValue == String{
+    public subscript<K: RawRepresentable>(key: K) -> XMLIndexer where K.RawValue == String {
         return self[key.rawValue]
     }
 }
 
-//MARK: - XMLElement String RawRepresentables
+// MARK: - XMLElement String RawRepresentables
 
 /*: Provides XMLIndexer Serialization/Deserialization using String backed RawRepresentables
  Added by [PeeJWeeJ](https://github.com/PeeJWeeJ) */
 extension XMLElement {
-    
     /** 
      Find an attribute by name using a String backed RawRepresentable (E.g. `String` backed `enum` cases)
      

--- a/Source/SWXMLHash.swift
+++ b/Source/SWXMLHash.swift
@@ -1043,3 +1043,73 @@ fileprivate extension String {
         return str1 == str2
     }
 }
+
+//MARK: - XMLIndexer String RawRepresentables
+
+/*: Provides XMLIndexer Serialization/Deserialization using String backed RawRepresentables
+    Added by [PeeJWeeJ](https://github.com/PeeJWeeJ) */
+extension XMLIndexer {
+    
+    /**
+     Allows for element lookup by matching attribute values
+     using a String backed RawRepresentables (E.g. `String` backed `enum` cases)
+     
+     - Note:
+     Convenience for withAttribute(String, String)
+     
+     - parameters:
+     - attr: should the name of the attribute to match on
+     - value: should be the value of the attribute to match on
+     - throws: an XMLIndexer.XMLError if an element with the specified attribute isn't found
+     - returns: instance of XMLIndexer
+     */
+    public func withAttribute<A: RawRepresentable, V: RawRepresentable>(_ attr: A, _ value: V) throws -> XMLIndexer where A.RawValue == String, V.RawValue == String {
+        return try withAttribute(attr.rawValue, value.rawValue)
+    }
+    
+    /**
+     Find an XML element at the current level by element name
+     using a String backed RawRepresentable (E.g. `String` backed `enum` cases)
+     
+     - Note:
+     Convenience for byKey(String)
+     
+     - parameter key: The element name to index by
+     - returns: instance of XMLIndexer to match the element (or elements) found by key
+     - throws: Throws an XMLIndexingError.Key if no element was found
+     */
+    public func byKey<K: RawRepresentable>(_ key: K) throws -> XMLIndexer where K.RawValue == String {
+        return try byKey(key.rawValue)
+    }
+    
+    /**
+     Find an XML element at the current level by element name
+     using a String backed RawRepresentable (E.g. `String` backed `enum` cases)
+     
+     - Note:
+     Convenience for self[String]
+     
+     - parameter key: The element name to index by
+     - returns: instance of XMLIndexer to match the element (or elements) found by
+     */
+    public subscript<K: RawRepresentable>(key: K) -> XMLIndexer where K.RawValue == String{
+        return self[key.rawValue]
+    }
+}
+
+//MARK: - XMLElement String RawRepresentables
+
+/*: Provides XMLIndexer Serialization/Deserialization using String backed RawRepresentables
+ Added by [PeeJWeeJ](https://github.com/PeeJWeeJ) */
+extension XMLElement {
+    
+    /** 
+     Find an attribute by name using a String backed RawRepresentable (E.g. `String` backed `enum` cases)
+     
+     - Note:
+     Convenience for self[String]
+     */
+    public func attribute<N: RawRepresentable>(by name: N) -> XMLAttribute? where N.RawValue == String {
+        return attribute(by: name.rawValue)
+    }
+}

--- a/Source/XMLIndexer+XMLIndexerDeserializable.swift
+++ b/Source/XMLIndexer+XMLIndexerDeserializable.swift
@@ -391,6 +391,86 @@ public extension XMLIndexer {
         }
     }
 }
+// MARK: - XMLAttributeDeserializable String RawRepresentable
+
+/*: Provides XMLIndexer XMLAttributeDeserializable deserialization from String backed RawRepresentables 
+    Added by [PeeJWeeJ](https://github.com/PeeJWeeJ) */
+public extension XMLIndexer {
+    
+    /**
+     Attempts to deserialize the value of the specified attribute of the current XMLIndexer
+     element to `T` using a String backed RawRepresentable (E.g. `String` backed `enum` cases)
+     
+     - Note:
+     Convenience for value(ofAttribute: String)
+     
+     - parameter attr: The attribute to deserialize
+     - throws: an XMLDeserializationError if there is a problem with deserialization
+     - returns: The deserialized `T` value
+     */
+    func value<T: XMLAttributeDeserializable, A: RawRepresentable>(ofAttribute attr: A) throws -> T where A.RawValue == String {
+        return try value(ofAttribute: attr.rawValue)
+    }
+    
+    /**
+     Attempts to deserialize the value of the specified attribute of the current XMLIndexer
+     element to `T?` using a String backed RawRepresentable (E.g. `String` backed `enum` cases)
+     
+     - Note:
+     Convenience for value(ofAttribute: String)
+     
+     - parameter attr: The attribute to deserialize
+     - returns: The deserialized `T?` value, or nil if the attribute does not exist
+     */
+    func value<T: XMLAttributeDeserializable, A: RawRepresentable>(ofAttribute attr: A) -> T? where A.RawValue == String {
+        return value(ofAttribute: attr.rawValue)
+    }
+    
+    /**
+     Attempts to deserialize the value of the specified attribute of the current XMLIndexer
+     element to `[T]` using a String backed RawRepresentable (E.g. `String` backed `enum` cases)
+     
+     - Note:
+     Convenience for value(ofAttribute: String)
+     
+     - parameter attr: The attribute to deserialize
+     - throws: an XMLDeserializationError if there is a problem with deserialization
+     - returns: The deserialized `[T]` value
+     */
+    func value<T: XMLAttributeDeserializable, A: RawRepresentable>(ofAttribute attr: A) throws -> [T] where A.RawValue == String {
+        return try value(ofAttribute: attr.rawValue)
+    }
+    
+    /**
+     Attempts to deserialize the value of the specified attribute of the current XMLIndexer
+     element to `[T]?` using a String backed RawRepresentable (E.g. `String` backed `enum` cases)
+     
+     - Note:
+     Convenience for value(ofAttribute: String)
+     
+     - parameter attr: The attribute to deserialize
+     - throws: an XMLDeserializationError if there is a problem with deserialization
+     - returns: The deserialized `[T]?` value
+     */
+    func value<T: XMLAttributeDeserializable, A: RawRepresentable>(ofAttribute attr: A) throws -> [T]? where A.RawValue == String {
+        return try value(ofAttribute: attr.rawValue)
+    }
+    
+    /**
+     Attempts to deserialize the value of the specified attribute of the current XMLIndexer
+     element to `[T?]` using a String backed RawRepresentable (E.g. `String` backed `enum` cases)
+     
+     - Note:
+     Convenience for value(ofAttribute: String)
+     
+     - parameter attr: The attribute to deserialize
+     - throws: an XMLDeserializationError if there is a problem with deserialization
+     - returns: The deserialized `[T?]` value
+     */
+    func value<T: XMLAttributeDeserializable, A: RawRepresentable>(ofAttribute attr: A) throws -> [T?] where A.RawValue == String {
+        return try value(ofAttribute: attr.rawValue)
+    }
+}
 
 // MARK: - XMLElement Extensions
 
@@ -438,6 +518,43 @@ extension XMLElement {
         }
 
         throw XMLDeserializationError.nodeHasNoValue
+    }
+}
+
+// MARK: String RawRepresentable
+
+/*: Provides XMLElement XMLAttributeDeserializable deserialization from String backed RawRepresentables
+    Added by [PeeJWeeJ](https://github.com/PeeJWeeJ) */
+public extension XMLElement {
+    
+    
+    /**
+     Attempts to deserialize the specified attribute of the current XMLElement to `T`
+     using a String backed RawRepresentable (E.g. `String` backed `enum` cases)
+     
+     - Note:
+     Convenience for value(ofAttribute: String)
+     
+     - parameter attr: The attribute to deserialize
+     - throws: an XMLDeserializationError if there is a problem with deserialization
+     - returns: The deserialized `T` value
+     */
+    public func value<T: XMLAttributeDeserializable, A: RawRepresentable>(ofAttribute attr: A)  throws -> T where A.RawValue == String {
+        return try value(ofAttribute: attr.rawValue)
+    }
+    
+    /**
+     Attempts to deserialize the specified attribute of the current XMLElement to `T?`
+     using a String backed RawRepresentable (E.g. `String` backed `enum` cases)
+     
+     - Note:
+     Convenience for value(ofAttribute: String)
+     
+     - parameter attr: The attribute to deserialize
+     - returns: The deserialized `T?` value, or nil if the attribute does not exist.
+     */
+    public func value<T: XMLAttributeDeserializable, A: RawRepresentable>(ofAttribute attr: A) -> T? where A.RawValue == String{
+        return value(ofAttribute: attr.rawValue)
     }
 }
 

--- a/Source/XMLIndexer+XMLIndexerDeserializable.swift
+++ b/Source/XMLIndexer+XMLIndexerDeserializable.swift
@@ -102,7 +102,6 @@ public extension XMLAttributeDeserializable {
 // MARK: - XMLIndexer Extensions
 
 public extension XMLIndexer {
-
     // MARK: - XMLAttributeDeserializable
 
     /**
@@ -391,12 +390,12 @@ public extension XMLIndexer {
         }
     }
 }
+
 // MARK: - XMLAttributeDeserializable String RawRepresentable
 
 /*: Provides XMLIndexer XMLAttributeDeserializable deserialization from String backed RawRepresentables 
     Added by [PeeJWeeJ](https://github.com/PeeJWeeJ) */
 public extension XMLIndexer {
-    
     /**
      Attempts to deserialize the value of the specified attribute of the current XMLIndexer
      element to `T` using a String backed RawRepresentable (E.g. `String` backed `enum` cases)
@@ -411,7 +410,7 @@ public extension XMLIndexer {
     func value<T: XMLAttributeDeserializable, A: RawRepresentable>(ofAttribute attr: A) throws -> T where A.RawValue == String {
         return try value(ofAttribute: attr.rawValue)
     }
-    
+
     /**
      Attempts to deserialize the value of the specified attribute of the current XMLIndexer
      element to `T?` using a String backed RawRepresentable (E.g. `String` backed `enum` cases)
@@ -425,7 +424,7 @@ public extension XMLIndexer {
     func value<T: XMLAttributeDeserializable, A: RawRepresentable>(ofAttribute attr: A) -> T? where A.RawValue == String {
         return value(ofAttribute: attr.rawValue)
     }
-    
+
     /**
      Attempts to deserialize the value of the specified attribute of the current XMLIndexer
      element to `[T]` using a String backed RawRepresentable (E.g. `String` backed `enum` cases)
@@ -440,7 +439,7 @@ public extension XMLIndexer {
     func value<T: XMLAttributeDeserializable, A: RawRepresentable>(ofAttribute attr: A) throws -> [T] where A.RawValue == String {
         return try value(ofAttribute: attr.rawValue)
     }
-    
+
     /**
      Attempts to deserialize the value of the specified attribute of the current XMLIndexer
      element to `[T]?` using a String backed RawRepresentable (E.g. `String` backed `enum` cases)
@@ -455,7 +454,7 @@ public extension XMLIndexer {
     func value<T: XMLAttributeDeserializable, A: RawRepresentable>(ofAttribute attr: A) throws -> [T]? where A.RawValue == String {
         return try value(ofAttribute: attr.rawValue)
     }
-    
+
     /**
      Attempts to deserialize the value of the specified attribute of the current XMLIndexer
      element to `[T?]` using a String backed RawRepresentable (E.g. `String` backed `enum` cases)
@@ -475,7 +474,6 @@ public extension XMLIndexer {
 // MARK: - XMLElement Extensions
 
 extension XMLElement {
-
     /**
      Attempts to deserialize the specified attribute of the current XMLElement to `T`
 
@@ -526,8 +524,6 @@ extension XMLElement {
 /*: Provides XMLElement XMLAttributeDeserializable deserialization from String backed RawRepresentables
     Added by [PeeJWeeJ](https://github.com/PeeJWeeJ) */
 public extension XMLElement {
-    
-    
     /**
      Attempts to deserialize the specified attribute of the current XMLElement to `T`
      using a String backed RawRepresentable (E.g. `String` backed `enum` cases)
@@ -542,7 +538,7 @@ public extension XMLElement {
     public func value<T: XMLAttributeDeserializable, A: RawRepresentable>(ofAttribute attr: A)  throws -> T where A.RawValue == String {
         return try value(ofAttribute: attr.rawValue)
     }
-    
+
     /**
      Attempts to deserialize the specified attribute of the current XMLElement to `T?`
      using a String backed RawRepresentable (E.g. `String` backed `enum` cases)
@@ -553,7 +549,7 @@ public extension XMLElement {
      - parameter attr: The attribute to deserialize
      - returns: The deserialized `T?` value, or nil if the attribute does not exist.
      */
-    public func value<T: XMLAttributeDeserializable, A: RawRepresentable>(ofAttribute attr: A) -> T? where A.RawValue == String{
+    public func value<T: XMLAttributeDeserializable, A: RawRepresentable>(ofAttribute attr: A) -> T? where A.RawValue == String {
         return value(ofAttribute: attr.rawValue)
     }
 }

--- a/Tests/SWXMLHashTests/TypeConversionBasicTypesTests.swift
+++ b/Tests/SWXMLHashTests/TypeConversionBasicTypesTests.swift
@@ -160,7 +160,8 @@ class TypeConversionBasicTypesTests: XCTestCase {
         let value: String? = parser!["root"]["attr"].value(ofAttribute: "missing")
         XCTAssertNil(value)
     }
-    
+
+    // swiftlint:disable nesting
     func testShouldConvertAttributeToNonOptionalWithStringRawRepresentable() {
         enum Keys: String {
             case string
@@ -172,7 +173,7 @@ class TypeConversionBasicTypesTests: XCTestCase {
             XCTFail("\(error)")
         }
     }
-    
+
     func testShouldConvertAttributeToOptionalWithStringRawRepresentable() {
         enum Keys: String {
             case string
@@ -180,7 +181,7 @@ class TypeConversionBasicTypesTests: XCTestCase {
         let value: String? = parser!["root"]["attr"].value(ofAttribute: Keys.string)
         XCTAssertEqual(value, "stringValue")
     }
-    
+
     func testShouldThrowWhenConvertingMissingAttributeToNonOptionalWithStringRawRepresentable() {
         enum Keys: String {
             case missing
@@ -192,7 +193,7 @@ class TypeConversionBasicTypesTests: XCTestCase {
             }
         }
     }
-    
+
     func testShouldConvertMissingAttributeToOptionalWithStringRawRepresentable() {
         enum Keys: String {
             case missing
@@ -544,7 +545,7 @@ class TypeConversionBasicTypesTests: XCTestCase {
             XCTFail("\(error)")
         }
     }
-    
+
     func testAttributeItemStringRawRepresentableShouldConvertAttributeItemToNonOptional() {
         do {
             let value: AttributeItemStringRawRepresentable = try parser!["root"]["attributeItem"].value()
@@ -553,7 +554,6 @@ class TypeConversionBasicTypesTests: XCTestCase {
             XCTFail("\(error)")
         }
     }
-    
 
     func testAttributeItemShouldThrowWhenConvertingEmptyToNonOptional() {
         XCTAssertThrowsError(try (parser!["root"]["empty"].value() as AttributeItem)) { error in
@@ -659,9 +659,10 @@ struct AttributeItemStringRawRepresentable: XMLElementDeserializable, Equatable 
         case name
         case price
     }
+
     let name: String
     let price: Double
-    
+
     static func deserialize(_ element: SWXMLHash.XMLElement) throws -> AttributeItemStringRawRepresentable {
         print("my deserialize")
         return try AttributeItemStringRawRepresentable(

--- a/Tests/SWXMLHashTests/TypeConversionBasicTypesTests.swift
+++ b/Tests/SWXMLHashTests/TypeConversionBasicTypesTests.swift
@@ -201,6 +201,7 @@ class TypeConversionBasicTypesTests: XCTestCase {
         let value: String? = parser!["root"]["attr"].value(ofAttribute: Keys.missing)
         XCTAssertNil(value)
     }
+    // swiftlint:enable nesting
 
     func testIntShouldConvertValueToNonOptional() {
         do {

--- a/Tests/SWXMLHashTests/TypeConversionBasicTypesTests.swift
+++ b/Tests/SWXMLHashTests/TypeConversionBasicTypesTests.swift
@@ -642,7 +642,7 @@ extension BasicItem: Equatable {
     }
 }
 
-struct AttributeItem: XMLElementDeserializable, Equatable {
+struct AttributeItem: XMLElementDeserializable {
     let name: String
     let price: Double
 
@@ -655,7 +655,13 @@ struct AttributeItem: XMLElementDeserializable, Equatable {
     }
 }
 
-struct AttributeItemStringRawRepresentable: XMLElementDeserializable, Equatable {
+extension AttributeItem: Equatable {
+    static func == (a: AttributeItem, b: AttributeItem) -> Bool {
+        return a.name == b.name && a.price == b.price
+    }
+}
+
+struct AttributeItemStringRawRepresentable: XMLElementDeserializable {
     private enum Keys: String {
         case name
         case price
@@ -670,6 +676,12 @@ struct AttributeItemStringRawRepresentable: XMLElementDeserializable, Equatable 
             name: element.value(ofAttribute: Keys.name),
             price: element.value(ofAttribute: Keys.price)
         )
+    }
+}
+
+extension AttributeItemStringRawRepresentable: Equatable {
+    static func == (a: AttributeItemStringRawRepresentable, b: AttributeItemStringRawRepresentable) -> Bool {
+        return a.name == b.name && a.price == b.price
     }
 }
 

--- a/Tests/SWXMLHashTests/TypeConversionBasicTypesTests.swift
+++ b/Tests/SWXMLHashTests/TypeConversionBasicTypesTests.swift
@@ -160,6 +160,46 @@ class TypeConversionBasicTypesTests: XCTestCase {
         let value: String? = parser!["root"]["attr"].value(ofAttribute: "missing")
         XCTAssertNil(value)
     }
+    
+    func testShouldConvertAttributeToNonOptionalWithStringRawRepresentable() {
+        enum Keys: String {
+            case string
+        }
+        do {
+            let value: String = try parser!["root"]["attr"].value(ofAttribute: Keys.string)
+            XCTAssertEqual(value, "stringValue")
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+    
+    func testShouldConvertAttributeToOptionalWithStringRawRepresentable() {
+        enum Keys: String {
+            case string
+        }
+        let value: String? = parser!["root"]["attr"].value(ofAttribute: Keys.string)
+        XCTAssertEqual(value, "stringValue")
+    }
+    
+    func testShouldThrowWhenConvertingMissingAttributeToNonOptionalWithStringRawRepresentable() {
+        enum Keys: String {
+            case missing
+        }
+        XCTAssertThrowsError(try (parser!["root"]["attr"].value(ofAttribute: Keys.missing) as String)) { error in
+            guard error is XMLDeserializationError else {
+                XCTFail("Wrong type of error")
+                return
+            }
+        }
+    }
+    
+    func testShouldConvertMissingAttributeToOptionalWithStringRawRepresentable() {
+        enum Keys: String {
+            case missing
+        }
+        let value: String? = parser!["root"]["attr"].value(ofAttribute: Keys.missing)
+        XCTAssertNil(value)
+    }
 
     func testIntShouldConvertValueToNonOptional() {
         do {
@@ -494,6 +534,7 @@ class TypeConversionBasicTypesTests: XCTestCase {
     }
 
     let correctAttributeItem = AttributeItem(name: "the name of attribute item", price: 19.99)
+    let correctAttributeItemStringRawRepresentable = AttributeItemStringRawRepresentable(name: "the name of attribute item", price: 19.99)
 
     func testAttributeItemShouldConvertAttributeItemToNonOptional() {
         do {
@@ -503,6 +544,16 @@ class TypeConversionBasicTypesTests: XCTestCase {
             XCTFail("\(error)")
         }
     }
+    
+    func testAttributeItemStringRawRepresentableShouldConvertAttributeItemToNonOptional() {
+        do {
+            let value: AttributeItemStringRawRepresentable = try parser!["root"]["attributeItem"].value()
+            XCTAssertEqual(value, correctAttributeItemStringRawRepresentable)
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+    
 
     func testAttributeItemShouldThrowWhenConvertingEmptyToNonOptional() {
         XCTAssertThrowsError(try (parser!["root"]["empty"].value() as AttributeItem)) { error in
@@ -590,7 +641,7 @@ extension BasicItem: Equatable {
     }
 }
 
-struct AttributeItem: XMLElementDeserializable {
+struct AttributeItem: XMLElementDeserializable, Equatable {
     let name: String
     let price: Double
 
@@ -603,9 +654,20 @@ struct AttributeItem: XMLElementDeserializable {
     }
 }
 
-extension AttributeItem: Equatable {
-    static func == (a: AttributeItem, b: AttributeItem) -> Bool {
-        return a.name == b.name && a.price == b.price
+struct AttributeItemStringRawRepresentable: XMLElementDeserializable, Equatable {
+    private enum Keys: String {
+        case name
+        case price
+    }
+    let name: String
+    let price: Double
+    
+    static func deserialize(_ element: SWXMLHash.XMLElement) throws -> AttributeItemStringRawRepresentable {
+        print("my deserialize")
+        return try AttributeItemStringRawRepresentable(
+            name: element.value(ofAttribute: Keys.name),
+            price: element.value(ofAttribute: Keys.price)
+        )
     }
 }
 
@@ -622,6 +684,10 @@ extension TypeConversionBasicTypesTests {
             ("testShouldConvertAttributeToOptional", testShouldConvertAttributeToOptional),
             ("testShouldThrowWhenConvertingMissingAttributeToNonOptional", testShouldThrowWhenConvertingMissingAttributeToNonOptional),
             ("testShouldConvertMissingAttributeToOptional", testShouldConvertMissingAttributeToOptional),
+            ("testShouldConvertAttributeToNonOptionalWithStringRawRepresentable", testShouldConvertAttributeToNonOptionalWithStringRawRepresentable),
+            ("testShouldConvertAttributeToOptionalWithStringRawRepresentable", testShouldConvertAttributeToOptionalWithStringRawRepresentable),
+            ("testShouldThrowWhenConvertingMissingAttributeToNonOptionalWithStringRawRepresentable", testShouldThrowWhenConvertingMissingAttributeToNonOptionalWithStringRawRepresentable),
+            ("testShouldConvertMissingAttributeToOptionalWithStringRawRepresentable", testShouldConvertMissingAttributeToOptionalWithStringRawRepresentable),
             ("testIntShouldConvertValueToNonOptional", testIntShouldConvertValueToNonOptional),
             ("testIntShouldThrowWhenConvertingEmptyToNonOptional", testIntShouldThrowWhenConvertingEmptyToNonOptional),
             ("testIntShouldThrowWhenConvertingMissingToNonOptional", testIntShouldThrowWhenConvertingMissingToNonOptional),
@@ -661,6 +727,7 @@ extension TypeConversionBasicTypesTests {
             ("testBasicItemShouldConvertEmptyToOptional", testBasicItemShouldConvertEmptyToOptional),
             ("testBasicItemShouldConvertMissingToOptional", testBasicItemShouldConvertMissingToOptional),
             ("testAttributeItemShouldConvertAttributeItemToNonOptional", testAttributeItemShouldConvertAttributeItemToNonOptional),
+            ("testAttributeItemStringRawRepresentableShouldConvertAttributeItemToNonOptional", testAttributeItemStringRawRepresentableShouldConvertAttributeItemToNonOptional),
             ("testAttributeItemShouldThrowWhenConvertingEmptyToNonOptional", testAttributeItemShouldThrowWhenConvertingEmptyToNonOptional),
             ("testAttributeItemShouldThrowWhenConvertingMissingToNonOptional", testAttributeItemShouldThrowWhenConvertingMissingToNonOptional),
             ("testAttributeItemShouldConvertAttributeItemToOptional", testAttributeItemShouldConvertAttributeItemToOptional),

--- a/Tests/SWXMLHashTests/TypeConversionPrimitypeTypesTests.swift
+++ b/Tests/SWXMLHashTests/TypeConversionPrimitypeTypesTests.swift
@@ -206,6 +206,7 @@ class TypeConversionPrimitypeTypesTests: XCTestCase {
             XCTFail("\(error)")
         }
     }
+    // swiftlint:enable nesting
 
     func testShouldConvertEmptyArrayOfIntsToNonOptional() {
         do {

--- a/Tests/SWXMLHashTests/TypeConversionPrimitypeTypesTests.swift
+++ b/Tests/SWXMLHashTests/TypeConversionPrimitypeTypesTests.swift
@@ -166,7 +166,8 @@ class TypeConversionPrimitypeTypesTests: XCTestCase {
             XCTFail("\(error)")
         }
     }
-    
+
+    // swiftlint:disable nesting
     func testShouldConvertArrayOfAttributeIntsToNonOptionalWithStringRawRepresentable() {
         enum Keys: String {
             case value
@@ -178,7 +179,7 @@ class TypeConversionPrimitypeTypesTests: XCTestCase {
             XCTFail("\(error)")
         }
     }
-    
+
     func testShouldConvertArrayOfAttributeIntsToOptionalWithStringRawRepresentable() {
         enum Keys: String {
             case value
@@ -193,7 +194,7 @@ class TypeConversionPrimitypeTypesTests: XCTestCase {
             XCTFail("\(error)")
         }
     }
-    
+
     func testShouldConvertArrayOfAttributeIntsToArrayOfOptionalsWithStringRawRepresentable() {
         enum Keys: String {
             case value

--- a/Tests/SWXMLHashTests/TypeConversionPrimitypeTypesTests.swift
+++ b/Tests/SWXMLHashTests/TypeConversionPrimitypeTypesTests.swift
@@ -166,6 +166,45 @@ class TypeConversionPrimitypeTypesTests: XCTestCase {
             XCTFail("\(error)")
         }
     }
+    
+    func testShouldConvertArrayOfAttributeIntsToNonOptionalWithStringRawRepresentable() {
+        enum Keys: String {
+            case value
+        }
+        do {
+            let value: [Int] = try parser!["root"]["arrayOfAttributeInts"]["int"].value(ofAttribute: Keys.value)
+            XCTAssertEqual(value, [0, 1, 2, 3])
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+    
+    func testShouldConvertArrayOfAttributeIntsToOptionalWithStringRawRepresentable() {
+        enum Keys: String {
+            case value
+        }
+        do {
+            let value: [Int]? = try parser!["root"]["arrayOfAttributeInts"]["int"].value(ofAttribute: Keys.value)
+            XCTAssertNotNil(value)
+            if let value = value {
+                XCTAssertEqual(value, [0, 1, 2, 3])
+            }
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+    
+    func testShouldConvertArrayOfAttributeIntsToArrayOfOptionalsWithStringRawRepresentable() {
+        enum Keys: String {
+            case value
+        }
+        do {
+            let value: [Int?] = try parser!["root"]["arrayOfAttributeInts"]["int"].value(ofAttribute: Keys.value)
+            XCTAssertEqual(value.compactMap({ $0 }), [0, 1, 2, 3])
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
 
     func testShouldConvertEmptyArrayOfIntsToNonOptional() {
         do {
@@ -210,6 +249,9 @@ extension TypeConversionPrimitypeTypesTests {
             ("testShouldConvertArrayOfAttributeIntsToNonOptional", testShouldConvertArrayOfAttributeIntsToNonOptional),
             ("testShouldConvertArrayOfAttributeIntsToOptional", testShouldConvertArrayOfAttributeIntsToOptional),
             ("testShouldConvertArrayOfAttributeIntsToArrayOfOptionals", testShouldConvertArrayOfAttributeIntsToArrayOfOptionals),
+            ("testShouldConvertArrayOfAttributeIntsToNonOptionalWithStringRawRepresentable", testShouldConvertArrayOfAttributeIntsToNonOptionalWithStringRawRepresentable),
+            ("testShouldConvertArrayOfAttributeIntsToOptionalWithStringRawRepresentable", testShouldConvertArrayOfAttributeIntsToOptionalWithStringRawRepresentable),
+            ("testShouldConvertArrayOfAttributeIntsToArrayOfOptionalsWithStringRawRepresentable", testShouldConvertArrayOfAttributeIntsToArrayOfOptionalsWithStringRawRepresentable),
             ("testShouldConvertEmptyArrayOfIntsToNonOptional", testShouldConvertEmptyArrayOfIntsToNonOptional),
             ("testShouldConvertEmptyArrayOfIntsToOptional", testShouldConvertEmptyArrayOfIntsToOptional),
             ("testShouldConvertEmptyArrayOfIntsToArrayOfOptionals", testShouldConvertEmptyArrayOfIntsToArrayOfOptionals)

--- a/Tests/SWXMLHashTests/XMLParsingTests.swift
+++ b/Tests/SWXMLHashTests/XMLParsingTests.swift
@@ -27,6 +27,7 @@ import SWXMLHash
 import XCTest
 
 // swiftlint:disable line_length
+// swiftlint:disable file_length
 // swiftlint:disable type_body_length
 
 class XMLParsingTests: XCTestCase {
@@ -74,12 +75,14 @@ class XMLParsingTests: XCTestCase {
         XCTAssertEqual(xml!["root"]["header"]["title"].element?.text, "Test Title Header")
     }
 
+    // swiftlint:disable nesting
     func testShouldBeAbleToParseIndividualElementsWithStringRawRepresentable() {
         enum Keys: String {
             case root; case header; case title
         }
         XCTAssertEqual(xml![Keys.root][Keys.header][Keys.title].element?.text, "Test Title Header")
     }
+    // swiftlint:enable nesting
 
     func testShouldBeAbleToParseElementGroups() {
         XCTAssertEqual(xml!["root"]["catalog"]["book"][1]["author"].element?.text, "Ralls, Kim")
@@ -97,8 +100,8 @@ class XMLParsingTests: XCTestCase {
         XCTAssertEqual(xml!["root"]["catalog"]["book"][1].element?.attribute(by: "id")?.text, "bk102")
     }
 
-    // swiftlint:disable identifier_name
     // swiftlint:disable nesting
+    // swiftlint:disable identifier_name
     func testShouldBeAbleToParseAttributesWithStringRawRepresentable() {
         enum Keys: String {
             case root; case catalog; case book; case id
@@ -126,6 +129,9 @@ class XMLParsingTests: XCTestCase {
             XCTFail("\(error)")
         }
     }
+
+    // swiftlint:enable nesting
+    // swiftlint:enable identifier_name
 
     func testShouldBeAbleToLookUpElementsByNameAndAttributeCaseInsensitive() {
         do {
@@ -258,6 +264,7 @@ class XMLParsingTests: XCTestCase {
         } catch { err = nil }
     }
 
+    // swiftlint:disable nesting
     /**
      Added Only test coverage for:
     `byKey<K: RawRepresentable>(_ key: K) throws -> XMLIndexer where K.RawValue == String`
@@ -276,6 +283,7 @@ class XMLParsingTests: XCTestCase {
             err = error
         } catch { err = nil }
     }
+    // swiftlint:enable nesting
 
     func testShouldProvideAnErrorElementWhenIndexersDontMatch() {
         var err: IndexingError?

--- a/Tests/SWXMLHashTests/XMLParsingTests.swift
+++ b/Tests/SWXMLHashTests/XMLParsingTests.swift
@@ -73,6 +73,13 @@ class XMLParsingTests: XCTestCase {
     func testShouldBeAbleToParseIndividualElements() {
         XCTAssertEqual(xml!["root"]["header"]["title"].element?.text, "Test Title Header")
     }
+    
+    func testShouldBeAbleToParseIndividualElementsWithStringRawRepresentable() {
+        enum Keys: String {
+            case root; case header; case title
+        }
+        XCTAssertEqual(xml![Keys.root][Keys.header][Keys.title].element?.text, "Test Title Header")
+    }
 
     func testShouldBeAbleToParseElementGroups() {
         XCTAssertEqual(xml!["root"]["catalog"]["book"][1]["author"].element?.text, "Ralls, Kim")
@@ -89,10 +96,29 @@ class XMLParsingTests: XCTestCase {
     func testShouldBeAbleToParseAttributes() {
         XCTAssertEqual(xml!["root"]["catalog"]["book"][1].element?.attribute(by: "id")?.text, "bk102")
     }
+    
+    func testShouldBeAbleToParseAttributesWithStringRawRepresentable() {
+        enum Keys: String {
+            case root; case catalog; case book; case id
+        }
+        XCTAssertEqual(xml![Keys.root][Keys.catalog][Keys.book][1].element?.attribute(by: Keys.id)?.text, "bk102")
+    }
 
     func testShouldBeAbleToLookUpElementsByNameAndAttribute() {
         do {
             let value = try xml!["root"]["catalog"]["book"].withAttribute("id", "bk102")["author"].element?.text
+            XCTAssertEqual(value, "Ralls, Kim")
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+    
+    func testShouldBeAbleToLookUpElementsByNameAndAttributeWithStringRawRepresentable() {
+        enum Keys: String {
+            case root; case catalog; case book; case id; case bk102; case author
+        }
+        do {
+            let value = try xml![Keys.root][Keys.catalog][Keys.book].withAttribute(Keys.id, Keys.bk102)[Keys.author].element?.text
             XCTAssertEqual(value, "Ralls, Kim")
         } catch {
             XCTFail("\(error)")
@@ -229,6 +255,25 @@ class XMLParsingTests: XCTestCase {
             err = error
         } catch { err = nil }
     }
+    
+    /**
+     Added Only test coverage for:
+    `byKey<K: RawRepresentable>(_ key: K) throws -> XMLIndexer where K.RawValue == String`
+     */
+    func testShouldProvideAnErrorObjectWhenKeysDontMatchWithStringRawRepresentable() {
+        enum Keys: String {
+            case root; case what; case header; case foo
+        }
+        var err: IndexingError?
+        defer {
+            XCTAssertNotNil(err)
+        }
+        do {
+            _ = try xml!.byKey(Keys.root).byKey(Keys.what).byKey(Keys.header).byKey(Keys.foo)
+        } catch let error as IndexingError {
+            err = error
+        } catch { err = nil }
+    }
 
     func testShouldProvideAnErrorElementWhenIndexersDontMatch() {
         var err: IndexingError?
@@ -339,11 +384,14 @@ extension XMLParsingTests {
     static var allTests: [(String, (XMLParsingTests) -> () throws -> Void)] {
         return [
             ("testShouldBeAbleToParseIndividualElements", testShouldBeAbleToParseIndividualElements),
+            ("testShouldBeAbleToParseIndividualElementsWithStringRawRepresentable", testShouldBeAbleToParseIndividualElementsWithStringRawRepresentable),
             ("testShouldBeAbleToParseElementGroups", testShouldBeAbleToParseElementGroups),
             ("testShouldBeAbleToParseElementGroupsByIndex", testShouldBeAbleToParseElementGroupsByIndex),
             ("testShouldBeAbleToByIndexWithoutGoingOutOfBounds", testShouldBeAbleToByIndexWithoutGoingOutOfBounds),
             ("testShouldBeAbleToParseAttributes", testShouldBeAbleToParseAttributes),
+            ("testShouldBeAbleToParseAttributesWithStringRawRepresentable", testShouldBeAbleToParseAttributesWithStringRawRepresentable),
             ("testShouldBeAbleToLookUpElementsByNameAndAttribute", testShouldBeAbleToLookUpElementsByNameAndAttribute),
+            ("testShouldBeAbleToLookUpElementsByNameAndAttributeWithStringRawRepresentable", testShouldBeAbleToLookUpElementsByNameAndAttributeWithStringRawRepresentable),
             ("testShouldBeAbleToLookUpElementsByNameAndAttributeCaseInsensitive", testShouldBeAbleToLookUpElementsByNameAndAttributeCaseInsensitive),
             ("testShouldBeAbleToIterateElementGroups", testShouldBeAbleToIterateElementGroups),
             ("testShouldBeAbleToIterateElementGroupsEvenIfOnlyOneElementIsFound", testShouldBeAbleToIterateElementGroupsEvenIfOnlyOneElementIsFound),
@@ -357,6 +405,7 @@ extension XMLParsingTests {
             ("testShouldBeAbleToProvideADescriptionForTheDocument", testShouldBeAbleToProvideADescriptionForTheDocument),
             ("testShouldReturnNilWhenKeysDontMatch", testShouldReturnNilWhenKeysDontMatch),
             ("testShouldProvideAnErrorObjectWhenKeysDontMatch", testShouldProvideAnErrorObjectWhenKeysDontMatch),
+            ("testShouldProvideAnErrorObjectWhenKeysDontMatchWithStringRawRepresentable", testShouldProvideAnErrorObjectWhenKeysDontMatchWithStringRawRepresentable),
             ("testShouldProvideAnErrorElementWhenIndexersDontMatch", testShouldProvideAnErrorElementWhenIndexersDontMatch),
             ("testShouldStillReturnErrorsWhenAccessingViaSubscripting", testShouldStillReturnErrorsWhenAccessingViaSubscripting),
             ("testShouldBeAbleToCreateASubIndexerFromFilter", testShouldBeAbleToCreateASubIndexerFromFilter),

--- a/Tests/SWXMLHashTests/XMLParsingTests.swift
+++ b/Tests/SWXMLHashTests/XMLParsingTests.swift
@@ -73,7 +73,7 @@ class XMLParsingTests: XCTestCase {
     func testShouldBeAbleToParseIndividualElements() {
         XCTAssertEqual(xml!["root"]["header"]["title"].element?.text, "Test Title Header")
     }
-    
+
     func testShouldBeAbleToParseIndividualElementsWithStringRawRepresentable() {
         enum Keys: String {
             case root; case header; case title
@@ -96,7 +96,9 @@ class XMLParsingTests: XCTestCase {
     func testShouldBeAbleToParseAttributes() {
         XCTAssertEqual(xml!["root"]["catalog"]["book"][1].element?.attribute(by: "id")?.text, "bk102")
     }
-    
+
+    // swiftlint:disable identifier_name
+    // swiftlint:disable nesting
     func testShouldBeAbleToParseAttributesWithStringRawRepresentable() {
         enum Keys: String {
             case root; case catalog; case book; case id
@@ -112,7 +114,7 @@ class XMLParsingTests: XCTestCase {
             XCTFail("\(error)")
         }
     }
-    
+
     func testShouldBeAbleToLookUpElementsByNameAndAttributeWithStringRawRepresentable() {
         enum Keys: String {
             case root; case catalog; case book; case id; case bk102; case author
@@ -255,7 +257,7 @@ class XMLParsingTests: XCTestCase {
             err = error
         } catch { err = nil }
     }
-    
+
     /**
      Added Only test coverage for:
     `byKey<K: RawRepresentable>(_ key: K) throws -> XMLIndexer where K.RawValue == String`


### PR DESCRIPTION
Added support for using String backed RawRepresentables in place of Strings for relevant APIs.	
This enables the use of String backed enums for those who use this design pattern without having to manually call `case.rawValue` everywhere.

e.g. given this enum:
```
enum Keys: String {
   case item
    case title
    case langauge
}
```
This enables
```
let title = try node[Keys.item][Keys.title]
let language: String = title.element?.value(ofAttribute: Keys.language)
```
Rather than 
```
let title = try node[Keys.item].rawValue[Keys.title.rawValue]
let language: String = title.element?.value(ofAttribute: Keys.language.rawValue)
```

Implementation details are fully contained extensions with simple convenience functions that mirror all naming with the String versions and simply call the original function/subscript with `parameter.rawValue`

Also added (passing) Unit Tests adjacent to other relevant tests. As there are no behavior changes I just made sure the new APIs had full test coverage and did not duplicate all the different Type tests.