### PR TITLE
Configure hound to use .swiftlint.yml

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,2 @@
+swiftlint:
+  config_file: .swiftlint.yml

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -57,6 +57,7 @@ opt_in_rules:
 file_name:
   excluded:
     - LinuxShims.swift
+    - shim.swift
 
 excluded:
   - Carthage


### PR DESCRIPTION
Per docs at http://help.houndci.com/configuration/swiftlint.