### PR TITLE
Raise swift version in SPM to 5.0, fixed deprecated semantics

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.0
 
 //
 //  SWXMLHash.swift

--- a/Tests/SWXMLHashTests/LinuxShims.swift
+++ b/Tests/SWXMLHashTests/LinuxShims.swift
@@ -29,7 +29,7 @@ import Foundation
 
     extension NSString {
         class func path(withComponents components: [String]) -> String {
-            return pathWithComponents(components)
+            return self.path(withComponents: components)
         }
     }
 


### PR DESCRIPTION
1) Pod's version of swift is 5.0, but SPM was 4.0
2) I didn't able to build the project on Ubuntu, so I've changed some semantics of NSString extesion for Linux