### PR TITLE
Support Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.xml text eol=lf

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,3 +33,18 @@ jobs:
         run: |
           eval "$(curl -sL https://gist.githubusercontent.com/kylef/5c0475ff02b7c7671d2a/raw/9f442512a46d7a2af7b850d65a7e9bd31edfb09b/swiftenv-install.sh)"
           swift test
+
+  windows-test:
+    name: Windows Test
+    runs-on: windows-latest
+
+    steps:
+      - name: Install Swift
+        uses: compnerd/gha-setup-swift@main
+        with:
+          branch: swift-5.8-release
+          tag: 5.8-RELEASE
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Build and test
+        run: swift test

--- a/Source/FullXMLParser.swift
+++ b/Source/FullXMLParser.swift
@@ -25,7 +25,7 @@
 
 import Foundation
 
-#if os(Linux)
+#if os(Linux) || os(Windows)
 import FoundationXML
 #endif
 

--- a/Source/LazyXMLParser.swift
+++ b/Source/LazyXMLParser.swift
@@ -25,7 +25,7 @@
 
 import Foundation
 
-#if os(Linux)
+#if os(Linux) || os(Windows)
 import FoundationXML
 #endif
 

--- a/Tests/SWXMLHashTests/LazyWhiteSpaceParsingTests.swift
+++ b/Tests/SWXMLHashTests/LazyWhiteSpaceParsingTests.swift
@@ -38,7 +38,7 @@ class LazyWhiteSpaceParsingTests: XCTestCase {
         // Put setup code here. This method is called before the invocation of each test method in the class.
 
 #if SWIFT_PACKAGE
-        let path = NSString.path(withComponents: NSString(string: #file).pathComponents.dropLast() + ["test.xml"])
+        let path = URL(fileURLWithPath: #file).deletingLastPathComponent().appendingPathComponent("test.xml").path
 #else
         let bundle = Bundle(for: WhiteSpaceParsingTests.self)
         let path = bundle.path(forResource: "test", ofType: "xml")!

--- a/Tests/SWXMLHashTests/WhiteSpaceParsingTests.swift
+++ b/Tests/SWXMLHashTests/WhiteSpaceParsingTests.swift
@@ -37,7 +37,7 @@ class WhiteSpaceParsingTests: XCTestCase {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
 #if SWIFT_PACKAGE
-        let path = NSString.path(withComponents: NSString(string: #file).pathComponents.dropLast() + ["test.xml"])
+        let path = URL(fileURLWithPath: #file).deletingLastPathComponent().appendingPathComponent("test.xml").path
 #else
         let bundle = Bundle(for: WhiteSpaceParsingTests.self)
         let path = bundle.path(forResource: "test", ofType: "xml")!

--- a/Tests/SWXMLHashTests/XMLParsingTests.swift
+++ b/Tests/SWXMLHashTests/XMLParsingTests.swift
@@ -375,7 +375,7 @@ class XMLParsingTests: XCTestCase {
 
         XCTAssertNotNil(err)
 
-#if !os(Linux)
+#if !(os(Linux) || os(Windows))
         if err != nil {
             XCTAssert(err!.line == 1)
         }


### PR DESCRIPTION
This set of patches enables building and passing the test suite on Windows.  Primarily, treat Windows and Linux similarly.  The platform specific behaviour here is the construction of the input paths where we now use `URL(fileURLWithPath:)` and `droppingLastPathComponent` and `addingPathComponent` to compute the location of the test input.