### PR TITLE
feat: add parent to XMLElement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v8.1.0 (September 27, 2024)
+
+- Added the `parent` property to `XMLElement` (via [#278](https://github.com/drmohundro/SWXMLHash/pull/278) which closes [#277](https://github.com/drmohundro/SWXMLHash/issues/277))
+
 ## v8.0.0 (September 17, 2024)
 
 - Added Swift 6.0 support (via [#283](https://github.com/drmohundro/SWXMLHash/pull/283))

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM swiftlang/swift:nightly-6.0-focal
+FROM swift:6.0
 
 ENV APP_HOME ./app
 RUN mkdir $APP_HOME

--- a/Source/XMLElement.swift
+++ b/Source/XMLElement.swift
@@ -30,6 +30,8 @@ public class XMLElement: XMLContent {
     /// The name of the element
     public let name: String
 
+    public private(set) var parent: XMLElement?
+
     /// Whether the element is case insensitive or not
     public var caseInsensitive: Bool {
         options.caseInsensitive
@@ -116,6 +118,7 @@ public class XMLElement: XMLContent {
 
     func addElement(_ name: String, withAttributes attributes: [String: String], caseInsensitive: Bool) -> XMLElement {
         let element = XMLElement(name: name, index: count, options: options)
+        element.parent = self
         count += 1
 
         children.append(element)

--- a/Tests/SWXMLHashTests/XMLParsingTests.swift
+++ b/Tests/SWXMLHashTests/XMLParsingTests.swift
@@ -89,6 +89,13 @@ struct XMLParsingTests {
     }
 
     @Test
+    func shouldBeAbleToGetParent() {
+        #expect(xml!["root"]["catalog"]["book"][1]["author"].element?.parent != nil)
+        #expect(xml!["root"]["catalog"]["book"][1]["author"].element?.parent?.name == "book")
+        #expect(xml!["root"]["catalog"]["book"][1]["author"].element?.parent?.attribute(by: "id")?.text == "bk102")
+    }
+
+    @Test
     func shouldBeAbleToParseElementGroupsByIndex() {
         // swiftlint:disable:next force_try
         #expect(try! xml!["root"]["catalog"]["book"].byIndex(1)["author"].element?.text == "Ralls, Kim")


### PR DESCRIPTION
Initial draft for a `parent` property for `XMLElement`... to cover #277.

Sample usage from the unit test:

```swift
    func testShouldBeAbleToGetParent() {
        XCTAssertNotNil(xml!["root"]["catalog"]["book"][1]["author"].element?.parent)
        XCTAssertEqual(xml!["root"]["catalog"]["book"][1]["author"].element?.parent?.name, "book")
        XCTAssertEqual(xml!["root"]["catalog"]["book"][1]["author"].element?.parent?.attribute(by: "id")?.text, "bk102")
    }
```