### PR TITLE
fix: add read permissions only for actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,9 @@ name: SwiftLint
 on:
   [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   docker-lint:
     name: Docker Lint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,9 @@ name: Main
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   mac-test:
     name: Mac Test


### PR DESCRIPTION
Trying to lock down the GitHub Actions a bit here.